### PR TITLE
Cross-compilation support

### DIFF
--- a/BBDown/BBDown.csproj
+++ b/BBDown/BBDown.csproj
@@ -10,23 +10,14 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>BBDown</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
-    <IlcOptimizationPreference>Speed</IlcOptimizationPreference>
-    <IlcFoldIdenticalMethodBodies>true</IlcFoldIdenticalMethodBodies>
-    <StaticallyLinked>true</StaticallyLinked>
-    <TrimMode>Link</TrimMode>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="6.0.0-*" />
     <PackageReference Include="protobuf-net" Version="3.0.101" />
     <PackageReference Include="QRCoder" Version="1.4.1" />
     <PackageReference Include="SharpZipLib" Version="1.3.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.21308.1" />
   </ItemGroup>
 
-  <ItemGroup>
-    <IlcArg Include="--reflectedonly" />
-    <RdXmlFile Include="rd.xml" />
-  </ItemGroup>
 </Project>

--- a/BBDown/Directory.Build.props
+++ b/BBDown/Directory.Build.props
@@ -1,0 +1,22 @@
+﻿<Project>
+
+  <PropertyGroup>
+    <IlcOptimizationPreference>Speed</IlcOptimizationPreference>
+    <IlcFoldIdenticalMethodBodies>true</IlcFoldIdenticalMethodBodies>
+    <StaticallyLinked>true</StaticallyLinked>
+    <TrimMode>Link</TrimMode>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="6.0.0-*" />
+    <!-- Cross-compilation for Windows x64-arm64 and Linux x64-arm64 -->
+    <PackageReference Condition="'$(RuntimeIdentifier)'=='win-arm64'" Include="runtime.win-x64.Microsoft.DotNet.ILCompiler" Version="6.0.0-*" />
+    <PackageReference Condition="'$(RuntimeIdentifier)'=='linux-arm64'" Include="runtime.linux-x64.Microsoft.DotNet.ILCompiler" Version="6.0.0-*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <IlcArg Include="--reflectedonly" />
+    <RdXmlFile Include="rd.xml" />
+  </ItemGroup>
+
+</Project>

--- a/nuget.config
+++ b/nuget.config
@@ -5,6 +5,5 @@
     <clear />
     <add key="dotnet-experimental" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="MyGet" value="https://www.myget.org/F/protobuf-net/api/v3/index.json" protocolVersion="3" />
  </packageSources>
 </configuration>


### PR DESCRIPTION
支持 x64-ARM64(Aarch64) 交叉编译

- Windows x64 编译 Windows ARM64
- Linux x64 编译 Linux ARM64

Native 工具链不支持 x86 和 ARM(ARMv7)，不过个人认为没有必要再发布 win-x86、linux-arm 和 win-arm 这三个版本。此外暂不支持 macOS ARM64。

如需交叉编译，发布 arm64 需要使用 native x64-arm64 交叉工具链，对于 Windows 可由 vs developer command prompt 脚本自动配置，对于 linux 需要手动指定 linker 和 sysroot，例如：
```
dotnet publish -r linux-arm64 -c Release -p:CppCompilerAndLinker=clang-12 -p:SysRoot=/crossrootfs/arm64
```

建议配置 GitHub Actions 自动构建。

另外，linux 和 macOS 版本经过 nativeaot 编译后符号文件包含在二进制中导致分发体积很大，可以通过 `strip BBDown` 命令删除掉符号部分，即可从 100+MB 减小到 25MB。