### PR TITLE
增加选项以设置输出路径

### DIFF
--- a/BBDown/Program.cs
+++ b/BBDown/Program.cs
@@ -70,6 +70,8 @@ namespace BBDown
             public string AccessToken { get; set; } = "";
             public string Aria2cProxy { get; set; } = "";
 
+            public string Output { get; set; } = "";
+
             public override string ToString()
             {
                 return $"{{Input={Url}, {nameof(UseTvApi)}={UseTvApi.ToString()}, " +
@@ -92,7 +94,8 @@ namespace BBDown
                     $"{nameof(SelectPage)}={SelectPage}, " +
                     $"{nameof(Cookie)}={Cookie}, " +
                     $"{nameof(AccessToken)}={AccessToken}, " +
-                    $"{nameof(Aria2cProxy)}={Aria2cProxy}}}";
+                    $"{nameof(Aria2cProxy)}={Aria2cProxy}, " +
+                    $"{nameof(Output)}={Output}}}";
             }
         }
 
@@ -177,7 +180,10 @@ namespace BBDown
                     "设置字符串cookie用以下载网页接口的会员内容"),
                 new Option<string>(
                     new string[]{ "--access-token" ,"-token"},
-                    "设置access_token用以下载TV/APP接口的会员内容")
+                    "设置access_token用以下载TV/APP接口的会员内容"),
+                new Option<string>(
+                    new string[]{ "--output" ,"-o"},
+                    "设置输出路径")
             };
 
             Command loginCommand = new Command(
@@ -349,6 +355,7 @@ namespace BBDown
                 string aidOri = ""; //原始aid
                 COOKIE = myOption.Cookie;
                 TOKEN = myOption.AccessToken.Replace("access_token=", "");
+                string output = myOption.Output;
 
                 //audioOnly和videoOnly同时开启则全部忽视
                 if (audioOnly && videoOnly)
@@ -542,7 +549,7 @@ namespace BBDown
                     string audioPath = $"{p.aid}/{p.aid}.P{indexStr}.{p.cid}.m4a";
                     //处理文件夹以.结尾导致的异常情况
                     if (title.EndsWith(".")) title += "_fix";
-                    string outPath = GetValidFileName(title) + (pagesInfo.Count > 1 ? $"/[P{indexStr}]{GetValidFileName(p.title)}" : (vInfo.PagesInfo.Count > 1 ? $"[P{indexStr}]{GetValidFileName(p.title)}" : "")) + ".mp4";
+                    string outPath = output != "" ? output : GetValidFileName(title) + (pagesInfo.Count > 1 ? $"/[P{indexStr}]{GetValidFileName(p.title)}" : (vInfo.PagesInfo.Count > 1 ? $"[P{indexStr}]{GetValidFileName(p.title)}" : "")) + ".mp4";
                     if (!infoMode && File.Exists(outPath) && new FileInfo(outPath).Length != 0)
                     {
                         Log($"{outPath}已存在, 跳过下载...");


### PR DESCRIPTION
首先感谢作者提供这样一个能 work 的 Bilibili headless 下载器！
此 PR 增加了 `-o` 选项以指定输出文件的路径，我本地测试了一下没有问题

#71 和 #35 都提到了希望允许自定义输出的文件名，此 PR 虽然没有实现像 youtube-dl 或 you-get 那样的文件名模版，但是使用 `-o` 指定输出路径已可以满足单视频下载控制输出文件名的需求了，也允许了在文件名可知的情况下后续做进一步的处理

此 `-o` hook 了 outPath 变量的生成，因此不提供 `-o` 时与没有此选项的行为是完全一样的，这样也不会干扰多视频下载时的状况