### PR TITLE
Disable statical link on non-Windows platforms

### DIFF
--- a/BBDown/Directory.Build.props
+++ b/BBDown/Directory.Build.props
@@ -1,9 +1,9 @@
-﻿<Project>
+<Project>
 
   <PropertyGroup>
     <IlcOptimizationPreference>Speed</IlcOptimizationPreference>
     <IlcFoldIdenticalMethodBodies>true</IlcFoldIdenticalMethodBodies>
-    <StaticallyLinked>true</StaticallyLinked>
+    <StaticallyLinked Condition="$(RuntimeIdentifier.StartsWith('win'))">true</StaticallyLinked>
     <TrimMode>Link</TrimMode>
   </PropertyGroup>
 


### PR DESCRIPTION
This may cause crashing at startup on non-Windows platforms.