### PR TITLE
.NET 6 and HttpClient migration

### DIFF
--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -3,7 +3,7 @@ name: Build Latest
 on: [push]
 
 env:
-  DOTNET_SDK_VERSION: '5.0.401'
+  DOTNET_SDK_VERSION: '6.0.100-rc.1.21463.6'
 
 jobs:
 
@@ -19,21 +19,22 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
+          include-prerelease: true
 
-      - run: dotnet publish -r win-x64 -c Release -o artifact
-      - run: dotnet publish -r win-arm64 -c Release
+      - run: dotnet publish -r win-x64 -c Release -o artifact-x64
+      - run: dotnet publish -r win-arm64 -c Release -o artifact-arm64
 
       - name: Upload Artifact[win-x64]
         uses: actions/upload-artifact@v1.0.0
         with:
           name: BBDown_win-x64
-          path: artifact\BBDown.exe
+          path: artifact-x64\BBDown.exe
 
       - name: Upload Artifact[win-arm64]
         uses: actions/upload-artifact@v1.0.0
         with:
           name: BBDown_win-arm64
-          path: BBDown\bin\Release\net5.0\win-arm64\native\BBDown.exe
+          path: artifact-arm64\BBDown.exe
   
 
   build-linux-x64:
@@ -47,6 +48,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
+          include-prerelease: true
       - run: sudo apt-get update
       - run: sudo apt-get install libcurl4-openssl-dev zlib1g-dev libkrb5-dev
       - run: dotnet publish -r linux-x64 -c Release -o artifact
@@ -70,6 +72,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
+          include-prerelease: true
       - run: dotnet publish -r linux-arm64 -c Release -p:CppCompilerAndLinker=clang-9 -p:SysRoot=/crossrootfs/arm64 -o artifact
       - run: aarch64-linux-gnu-strip artifact/BBDown
       
@@ -82,7 +85,7 @@ jobs:
   build-linux-musl-x64:
 
     runs-on: ubuntu-latest
-    container: mcr.microsoft.com/dotnet/sdk:5.0-alpine
+    container: mcr.microsoft.com/dotnet/sdk:6.0-alpine
 
     steps:
       - uses: actions/checkout@v2
@@ -107,6 +110,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
+          include-prerelease: true
       - run: dotnet publish -r osx-x64 -c Release -o artifact
       - run: strip artifact/BBDown
       

--- a/BBDown/BBDown.csproj
+++ b/BBDown/BBDown.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Version>1.4.0</Version>
     <Description>BBDown是一个免费且便捷高效的哔哩哔哩下载/解析软件.</Description>
     <PackageProjectUrl>https://github.com/nilaoda/BBDown</PackageProjectUrl>

--- a/BBDown/BBDownAppHelper.cs
+++ b/BBDown/BBDownAppHelper.cs
@@ -218,7 +218,7 @@ namespace BBDown
         /// </summary>
         /// <param name="obj"></param>
         /// <returns></returns>
-        private static byte[] ObjectToBytes(Object obj)
+        private static byte[] ObjectToBytes(object obj)
         {
             using (var stream = new MemoryStream())
             {
@@ -232,7 +232,7 @@ namespace BBDown
         /// </summary>
         /// <param name="obj"></param>
         /// <returns></returns>
-        private static string SerializeToBase64(Object obj)
+        private static string SerializeToBase64(object obj)
         {
             return Convert.ToBase64String(ObjectToBytes(obj)).TrimEnd('=');
         }

--- a/BBDown/BBDownAppHelper.cs
+++ b/BBDown/BBDownAppHelper.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading.Tasks;
 using static BBDown.BBDownLogger;
 
 namespace BBDown
@@ -44,13 +45,13 @@ namespace BBDown
         /// <param name="qn"></param>
         /// <param name="appkey"></param>
         /// <returns></returns>
-        public static string DoReq(string aid, string cid, string qn, bool bangumi, bool onlyAvc, string appkey = "")
+        public static async Task<string> DoReqAsync(string aid, string cid, string qn, bool bangumi, bool onlyAvc, string appkey = "")
         {
             var headers = GetHeader(appkey);
             LogDebug("App-Req-Headers: {0}", ConvertToString(headers));
             var body = GetPayload(Convert.ToInt64(aid), Convert.ToInt64(cid), Convert.ToInt64(qn), onlyAvc ? PlayViewReq.CodeType.Code264 : PlayViewReq.CodeType.Code265);
             //Console.WriteLine(ReadMessage<PlayViewReq>(body));
-            var data = GetPostResponse(bangumi ? API : API, body, headers);
+            var data = await GetPostResponseAsync(bangumi ? API : API, body, headers);
             var resp = ReadMessage<PlayViewReply>(data);
             LogDebug("PlayViewReplyPlain: {0}", ConvertToString(resp));
             return ConvertToDashJson(resp);
@@ -356,15 +357,9 @@ namespace BBDown
             }
         }
 
-        public static byte[] GetPostResponse(string Url, byte[] postData, Dictionary<string, string> headers)
+        public static async Task<byte[]> GetPostResponseAsync(string Url, byte[] postData, Dictionary<string, string> headers)
         {
             LogDebug("Post to: {0}, data: {1}", Url, Convert.ToBase64String(postData));
-
-            HttpClient client = new HttpClient(new HttpClientHandler
-            {
-                AllowAutoRedirect = true,
-                //Proxy = null
-            });
 
             ByteArrayContent content = new ByteArrayContent(postData);
             content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/grpc");
@@ -381,8 +376,8 @@ namespace BBDown
                 foreach (KeyValuePair<string, string> header in headers)
                     request.Headers.TryAddWithoutValidation(header.Key, header.Value);
 
-            HttpResponseMessage response = client.SendAsync(request).Result;
-            byte[] bytes = response.Content.ReadAsByteArrayAsync().Result;
+            HttpResponseMessage response = await BBDownUtil.AppHttpClient.SendAsync(request);
+            byte[] bytes = await response.Content.ReadAsByteArrayAsync();
 
             return bytes;
         }

--- a/BBDown/BBDownAria2c.cs
+++ b/BBDown/BBDownAria2c.cs
@@ -1,30 +1,31 @@
 ﻿using System.Diagnostics;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace BBDown
 {
     class BBDownAria2c
     {
-        public static int RunCommandCode(string command, string args)
+        public static async Task<int> RunCommandCodeAsync(string command, string args)
         {
-            Process p = new Process();
+            using Process p = new Process();
             p.StartInfo.UseShellExecute = false;
             p.StartInfo.RedirectStandardOutput = false;
             p.StartInfo.FileName = command;
             p.StartInfo.Arguments = args;
             p.Start();
-            p.WaitForExit();
+            await p.WaitForExitAsync();
             return p.ExitCode;
         }
 
-        public static void DownloadFileByAria2c(string url, string path, string proxy)
+        public static async Task DownloadFileByAria2cAsync(string url, string path, string proxy)
         {
             var headerArgs = "";
             if (!url.Contains("platform=android_tv_yst") && !url.Contains("platform=android"))
                 headerArgs += " --header=\"Referer: https://www.bilibili.com\"";
             headerArgs += " --header=\"User-Agent: Mozilla/5.0\"";
             headerArgs += $" --header=\"Cookie: {Program.COOKIE}\"";
-            RunCommandCode("aria2c", $"{(proxy == "" ? "" : "--all-proxy=" + proxy)} --auto-file-renaming=false --download-result=hide --allow-overwrite=true --console-log-level=warn -x16 -s16 -k5M {headerArgs} \"{url}\" -d \"{Path.GetDirectoryName(path)}\" -o \"{Path.GetFileName(path)}\"");
+            await RunCommandCodeAsync("aria2c", $"{(proxy == "" ? "" : "--all-proxy=" + proxy)} --auto-file-renaming=false --download-result=hide --allow-overwrite=true --console-log-level=warn -x16 -s16 -k5M {headerArgs} \"{url}\" -d \"{Path.GetDirectoryName(path)}\" -o \"{Path.GetFileName(path)}\"");
         }
     }
 }

--- a/BBDown/BBDownBangumiInfoFetcher.cs
+++ b/BBDown/BBDownBangumiInfoFetcher.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Threading.Tasks;
 using static BBDown.BBDownEntity;
 using static BBDown.BBDownUtil;
 
@@ -9,12 +10,12 @@ namespace BBDown
 {
     class BBDownBangumiInfoFetcher : IFetcher
     {
-        public BBDownVInfo Fetch(string id)
+        public async Task<BBDownVInfo> FetchAsync(string id)
         {
             id = id.Substring(3);
             string index = "";
             string api = $"https://api.bilibili.com/pgc/view/web/season?ep_id={id}";
-            string json = GetWebSource(api);
+            string json = await GetWebSourceAsync(api);
             using var infoJson = JsonDocument.Parse(json);
             var result = infoJson.RootElement.GetProperty("result");
             string cover = result.GetProperty("cover").ToString();

--- a/BBDown/BBDownCheeseInfoFetcher.cs
+++ b/BBDown/BBDownCheeseInfoFetcher.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using System.Threading.Tasks;
 using static BBDown.BBDownEntity;
 using static BBDown.BBDownUtil;
 
@@ -10,12 +11,12 @@ namespace BBDown
 {
     class BBDownCheeseInfoFetcher : IFetcher
     {
-        public BBDownVInfo Fetch(string id)
+        public async Task<BBDownVInfo> FetchAsync(string id)
         {
             id = id.Substring(7);
             string index = "";
             string api = $"https://api.bilibili.com/pugv/view/web/season?ep_id={id}";
-            string json = GetWebSource(api);
+            string json = await GetWebSourceAsync(api);
             using var infoJson = JsonDocument.Parse(json);
             var data = infoJson.RootElement.GetProperty("data");
             string cover = data.GetProperty("cover").ToString();

--- a/BBDown/BBDownIntlBangumiInfoFetcher.cs
+++ b/BBDown/BBDownIntlBangumiInfoFetcher.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using static BBDown.BBDownEntity;
 using static BBDown.BBDownUtil;
 
@@ -11,13 +12,13 @@ namespace BBDown
 {
     class BBDownIntlBangumiInfoFetcher : IFetcher
     {
-        public BBDownVInfo Fetch(string id)
+        public async Task<BBDownVInfo> FetchAsync(string id)
         {
             id = id.Substring(3);
             string index = "";
             //string api = $"https://api.global.bilibili.com/intl/gateway/ogv/m/view?ep_id={id}&s_locale=ja_JP";
             string api = $"https://api.global.bilibili.com/intl/gateway/v2/ogv/view/app/season?ep_id={id}&platform=android&s_locale=zh_SG&mobi_app=bstar_a" + (Program.TOKEN != "" ? $"&access_key={Program.TOKEN}" : "");
-            string json = GetWebSource(api);
+            string json = await GetWebSourceAsync(api);
             using var infoJson = JsonDocument.Parse(json);
             var result = infoJson.RootElement.GetProperty("result");
             string seasonId = result.GetProperty("season_id").ToString();
@@ -29,7 +30,7 @@ namespace BBDown
             if (cover == "")
             {
                 string animeUrl = $"https://bangumi.bilibili.com/anime/{seasonId}";
-                var web = GetWebSource(animeUrl);
+                var web = await GetWebSourceAsync(animeUrl);
                 if (web != "")
                 {
                     Regex regex = new Regex("window.__INITIAL_STATE__=([\\s\\S].*?);\\(function\\(\\)");

--- a/BBDown/BBDownNormalInfoFetcher.cs
+++ b/BBDown/BBDownNormalInfoFetcher.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using static BBDown.BBDownEntity;
 using static BBDown.BBDownUtil;
 
@@ -11,10 +12,10 @@ namespace BBDown
 {
     class BBDownNormalInfoFetcher : IFetcher
     {
-        public BBDownVInfo Fetch(string id)
+        public async Task<BBDownVInfo> FetchAsync(string id)
         {
             string api = $"https://api.bilibili.com/x/web-interface/view?aid={id}";
-            string json = GetWebSource(api);
+            string json = await GetWebSourceAsync(api);
             using var infoJson = JsonDocument.Parse(json);
             var data = infoJson.RootElement.GetProperty("data");
             string title = data.GetProperty("title").ToString();

--- a/BBDown/BBDownParser.cs
+++ b/BBDown/BBDownParser.cs
@@ -24,7 +24,7 @@ namespace BBDown
             bool bangumi = cheese || aidOri.StartsWith("ep:");
             LogDebug("bangumi={0},cheese={1}", bangumi, cheese);
 
-            if (appApi) return BBDownAppHelper.DoReq(aid, cid, qn, bangumi, onlyAvc, Program.TOKEN);
+            if (appApi) return await BBDownAppHelper.DoReqAsync(aid, cid, qn, bangumi, onlyAvc, Program.TOKEN);
 
             string prefix = tvApi ? (bangumi ? "api.snm0516.aisee.tv/pgc/player/api/playurltv" : "api.snm0516.aisee.tv/x/tv/ugc/playurl")
                         : (bangumi ? "api.bilibili.com/pgc/player/web/playurl" : "api.bilibili.com/x/player/playurl");

--- a/BBDown/BBDownParser.cs
+++ b/BBDown/BBDownParser.cs
@@ -7,16 +7,17 @@ using static BBDown.BBDownLogger;
 using static BBDown.BBDownEntity;
 using System.Linq;
 using System.Text.Json;
+using System.Threading.Tasks;
 
 namespace BBDown
 {
     class BBDownParser
     {
-        private static string GetPlayJson(bool onlyAvc, string aidOri, string aid, string cid, string epId, bool tvApi, bool intl, bool appApi, string qn = "0")
+        private static async Task<string> GetPlayJsonAsync(bool onlyAvc, string aidOri, string aid, string cid, string epId, bool tvApi, bool intl, bool appApi, string qn = "0")
         {
             LogDebug("aid={0},cid={1},epId={2},tvApi={3},IntlApi={4},appApi={5},qn={6}", aid, cid, epId, tvApi, intl, appApi, qn);
 
-            if (intl) return GetPlayJson(aid, cid, epId, qn);
+            if (intl) return await GetPlayJsonAsync(aid, cid, epId, qn);
 
 
             bool cheese = aidOri.StartsWith("cheese:");
@@ -48,26 +49,26 @@ namespace BBDown
             if (cheese) api = api.Replace("/pgc/", "/pugv/");
 
             //Console.WriteLine(api);
-            string webJson = GetWebSource(api);
+            string webJson = await GetWebSourceAsync(api);
             //以下情况从网页源代码尝试解析
             if (webJson.Contains("\"大会员专享限制\""))
             {
                 string webUrl = "https://www.bilibili.com/bangumi/play/ep" + epId;
-                string webSource = GetWebSource(webUrl);
+                string webSource = await GetWebSourceAsync(webUrl);
                 webJson = Regex.Match(webSource, @"window.__playinfo__=([\s\S]*?)<\/script>").Groups[1].Value;
             }
             return webJson;
         }
 
-        private static string GetPlayJson(string aid, string cid, string epId, string qn)
+        private static async Task<string> GetPlayJsonAsync(string aid, string cid, string epId, string qn)
         {
             string api = $"https://api.global.bilibili.com/intl/gateway/v2/ogv/playurl?" +
                 $"aid={aid}&cid={cid}&ep_id={epId}&platform=android&prefer_code_type=0&qn={qn}" + (Program.TOKEN != "" ? $"&access_key={Program.TOKEN}" : "");
-            string webJson = GetWebSource(api);
+            string webJson = await GetWebSourceAsync(api);
             return webJson;
         }
 
-        public static (string, List<Video>, List<Audio>, List<string>, List<string>) ExtractTracks(bool onlyHevc, bool onlyAvc, string aidOri, string aid, string cid, string epId, bool tvApi, bool intlApi, bool appApi, string qn = "0")
+        public static async Task<(string, List<Video>, List<Audio>, List<string>, List<string>)> ExtractTracksAsync(bool onlyHevc, bool onlyAvc, string aidOri, string aid, string cid, string epId, bool tvApi, bool intlApi, bool appApi, string qn = "0")
         {
             List<Video> videoTracks = new List<Video>();
             List<Audio> audioTracks = new List<Audio>();
@@ -75,7 +76,7 @@ namespace BBDown
             List<string> dfns = new List<string>();
 
             //调用解析
-            string webJsonStr = GetPlayJson(onlyAvc, aidOri, aid, cid, epId, tvApi, intlApi, appApi);
+            string webJsonStr = await GetPlayJsonAsync(onlyAvc, aidOri, aid, cid, epId, tvApi, intlApi, appApi);
 
             var respJson = JsonDocument.Parse(webJsonStr);
             var data = respJson.RootElement;
@@ -138,7 +139,7 @@ namespace BBDown
             reParse:
                 if (reParse)
                 {
-                    webJsonStr = GetPlayJson(onlyAvc, aidOri, aid, cid, epId, tvApi, intlApi, appApi, GetMaxQn());
+                    webJsonStr = await GetPlayJsonAsync(onlyAvc, aidOri, aid, cid, epId, tvApi, intlApi, appApi, GetMaxQn());
                     respJson = JsonDocument.Parse(webJsonStr);
                 }
                 try { video = !tvApi ? respJson.RootElement.GetProperty(nodeName).GetProperty("dash").GetProperty("video").EnumerateArray().ToList() : respJson.RootElement.GetProperty("dash").GetProperty("video").EnumerateArray().ToList(); } catch { }
@@ -190,7 +191,7 @@ namespace BBDown
             else if (webJsonStr.Contains("\"durl\":[")) //flv
             {
                 //默认以最高清晰度解析
-                webJsonStr = GetPlayJson(onlyAvc, aidOri, aid, cid, epId, tvApi, intlApi, appApi, GetMaxQn());
+                webJsonStr = await GetPlayJsonAsync(onlyAvc, aidOri, aid, cid, epId, tvApi, intlApi, appApi, GetMaxQn());
                 respJson = JsonDocument.Parse(webJsonStr);
                 string quality = "";
                 string videoCodecid = "";

--- a/BBDown/BBDownUtil.cs
+++ b/BBDown/BBDownUtil.cs
@@ -283,7 +283,7 @@ namespace BBDown
             LogDebug("Start downloading: {0}", url);
             if (aria2c)
             {
-                BBDownAria2c.DownloadFileByAria2c(url, path, aria2cProxy);
+                await BBDownAria2c.DownloadFileByAria2cAsync(url, path, aria2cProxy);
                 if (File.Exists(path + ".aria2") || !File.Exists(path))
                     throw new Exception("aria2下载可能存在错误");
                 Console.WriteLine();
@@ -322,7 +322,7 @@ namespace BBDown
         {
             if (aria2c)
             {
-                BBDownAria2c.DownloadFileByAria2c(url, path, aria2cProxy);
+                await BBDownAria2c.DownloadFileByAria2cAsync(url, path, aria2cProxy);
                 if (File.Exists(path + ".aria2") || !File.Exists(path))
                     throw new Exception("aria2下载可能存在错误");
                 Console.WriteLine();

--- a/BBDown/BBDownUtil.cs
+++ b/BBDown/BBDownUtil.cs
@@ -21,9 +21,14 @@ using static BBDown.BBDownLogger;
 
 namespace BBDown
 {
-    class BBDownUtil
+    static class BBDownUtil
     {
-        private static readonly HttpClient httpClient = new();
+        public static readonly HttpClient AppHttpClient = new(new HttpClientHandler
+        {
+            AllowAutoRedirect = true,
+            AutomaticDecompression = DecompressionMethods.All
+        });
+
         public static async Task CheckUpdateAsync()
         {
             try
@@ -55,11 +60,11 @@ namespace BBDown
                 }
                 else if (input.Contains("video/BV"))
                 {
-                    return GetAidByBV(Regex.Match(input, "BV(\\w+)").Groups[1].Value);
+                    return await GetAidByBVAsync(Regex.Match(input, "BV(\\w+)").Groups[1].Value);
                 }
                 else if (input.Contains("video/bv"))
                 {
-                    return GetAidByBV(Regex.Match(input, "bv(\\w+)").Groups[1].Value);
+                    return await GetAidByBVAsync(Regex.Match(input, "bv(\\w+)").Groups[1].Value);
                 }
                 else if (input.Contains("/cheese/"))
                 {
@@ -70,7 +75,7 @@ namespace BBDown
                     }
                     else if (input.Contains("/ss"))
                     {
-                        epId = GetEpidBySSId(Regex.Match(input, "/ss(\\d{1,})").Groups[1].Value);
+                        epId = await GetEpidBySSIdAsync(Regex.Match(input, "/ss(\\d{1,})").Groups[1].Value);
                     }
                     return $"cheese:{epId}";
                 }
@@ -96,7 +101,7 @@ namespace BBDown
                 }
                 else
                 {
-                    string web = GetWebSource(input);
+                    string web = await GetWebSourceAsync(input);
                     Regex regex = new Regex("window.__INITIAL_STATE__=([\\s\\S].*?);\\(function\\(\\)");
                     string json = regex.Match(web).Groups[1].Value;
                     using var jDoc = JsonDocument.Parse(json);
@@ -106,11 +111,11 @@ namespace BBDown
             }
             else if (input.StartsWith("BV"))
             {
-                return GetAidByBV(input.Substring(2));
+                return await GetAidByBVAsync(input.Substring(2));
             }
             else if (input.StartsWith("bv"))
             {
-                return GetAidByBV(input.Substring(2));
+                return await GetAidByBVAsync(input.Substring(2));
             }
             else if (input.ToLower().StartsWith("av")) //av
             {
@@ -123,7 +128,7 @@ namespace BBDown
             }
             else if (input.StartsWith("ss"))
             {
-                string web = GetWebSource("https://www.bilibili.com/bangumi/play/" + input);
+                string web = await GetWebSourceAsync("https://www.bilibili.com/bangumi/play/" + input);
                 Regex regex = new Regex("window.__INITIAL_STATE__=([\\s\\S].*?);\\(function\\(\\)");
                 string json = regex.Match(web).Groups[1].Value;
                 using var jDoc = JsonDocument.Parse(json);
@@ -136,7 +141,7 @@ namespace BBDown
             }
         }
 
-        public static String FormatFileSize(Double fileSize)
+        public static string FormatFileSize(double fileSize)
         {
             if (fileSize < 0)
             {
@@ -144,15 +149,15 @@ namespace BBDown
             }
             else if (fileSize >= 1024 * 1024 * 1024)
             {
-                return string.Format("{0:########0.00} GB", ((Double)fileSize) / (1024 * 1024 * 1024));
+                return string.Format("{0:########0.00} GB", ((double)fileSize) / (1024 * 1024 * 1024));
             }
             else if (fileSize >= 1024 * 1024)
             {
-                return string.Format("{0:####0.00} MB", ((Double)fileSize) / (1024 * 1024));
+                return string.Format("{0:####0.00} MB", ((double)fileSize) / (1024 * 1024));
             }
             else if (fileSize >= 1024)
             {
-                return string.Format("{0:####0.00} KB", ((Double)fileSize) / 1024);
+                return string.Format("{0:####0.00} KB", ((double)fileSize) / 1024);
             }
             else
             {
@@ -160,7 +165,7 @@ namespace BBDown
             }
         }
 
-        public static String FormatTime(Int32 time)
+        public static string FormatTime(int time)
         {
             TimeSpan ts = new TimeSpan(0, 0, time);
             string str = "";
@@ -168,59 +173,24 @@ namespace BBDown
             return str;
         }
 
-        public static string GetWebSource(String url)
+        public static async Task<string> GetWebSourceAsync(string url)
         {
             string htmlCode = string.Empty;
             try
             {
-                HttpWebRequest webRequest = (HttpWebRequest)WebRequest.Create(url);
-                webRequest.Method = "GET";
-                webRequest.UserAgent = "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36";
+                using var webRequest = new HttpRequestMessage(HttpMethod.Get, url);
+                webRequest.Headers.Add("UserAgent", "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36");
                 webRequest.Headers.Add("Accept-Encoding", "gzip, deflate");
                 webRequest.Headers.Add("Cookie", (url.Contains("/ep") || url.Contains("/ss")) ? Program.COOKIE + ";CURRENT_FNVAL=80;" : Program.COOKIE);
                 if (url.Contains("api.bilibili.com/pgc/player/web/playurl") || url.Contains("api.bilibili.com/pugv/player/web/playurl"))
                     webRequest.Headers.Add("Referer", "https://www.bilibili.com");
-                webRequest.CachePolicy = new HttpRequestCachePolicy(HttpRequestCacheLevel.NoCacheNoStore);
-                webRequest.KeepAlive = false;
-                webRequest.AllowAutoRedirect = true;  //自动跳转
+                webRequest.Headers.CacheControl = CacheControlHeaderValue.Parse("no-cache");
+                webRequest.Headers.Connection.Clear();
+
                 LogDebug("获取网页内容：Url: {0}, Headers: {1}", url, webRequest.Headers);
+                var webResponse = (await AppHttpClient.SendAsync(webRequest, HttpCompletionOption.ResponseHeadersRead)).EnsureSuccessStatusCode();
 
-                HttpWebResponse webResponse = (HttpWebResponse)webRequest.GetResponse();
-                if (webResponse.ContentEncoding != null
-                    && webResponse.ContentEncoding.ToLower() == "gzip") //如果使用了GZip则先解压
-                {
-                    using (Stream streamReceive = webResponse.GetResponseStream())
-                    {
-                        using (var zipStream =
-                            new GZipInputStream(streamReceive))
-                        {
-                            using (StreamReader sr = new StreamReader(zipStream, Encoding.UTF8))
-                            {
-                                htmlCode = sr.ReadToEnd();
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    using (Stream streamReceive = webResponse.GetResponseStream())
-                    {
-                        using (StreamReader sr = new StreamReader(streamReceive, Encoding.UTF8))
-                        {
-                            htmlCode = sr.ReadToEnd();
-                        }
-                    }
-                }
-
-                if (webResponse != null)
-                {
-                    webResponse.Close();
-                }
-                if (webRequest != null)
-                {
-                    webRequest.Abort();
-                }
-
+                htmlCode = await webResponse.Content.ReadAsStringAsync();
             }
             catch (Exception)
             {
@@ -230,70 +200,35 @@ namespace BBDown
             return htmlCode;
         }
 
-        public static string GetPostResponse(string Url, byte[] postData)
+        public static async Task<string> GetPostResponseAsync(string Url, byte[] postData)
         {
             LogDebug("Post to: {0}, data: {1}", Url, Convert.ToBase64String(postData));
             string htmlCode = string.Empty;
-            HttpWebRequest request = (HttpWebRequest)WebRequest.Create(Url);
-            request.Method = "POST";
-            request.ContentType = "application/grpc";
-            request.ContentLength = postData.Length;
-            request.UserAgent = "Dalvik/2.1.0 (Linux; U; Android 6.0.1; oneplus a5010 Build/V417IR) 6.10.0 os/android model/oneplus a5010 mobi_app/android build/6100500 channel/bili innerVer/6100500 osVer/6.0.1 network/2";
+            using HttpRequestMessage request = new(HttpMethod.Post, Url);
+            request.Headers.Add("ContentType", "application/grpc");
+            request.Headers.Add("ContentLength", postData.Length.ToString());
+            request.Headers.Add("UserAgent", "Dalvik/2.1.0 (Linux; U; Android 6.0.1; oneplus a5010 Build/V417IR) 6.10.0 os/android model/oneplus a5010 mobi_app/android build/6100500 channel/bili innerVer/6100500 osVer/6.0.1 network/2");
             request.Headers.Add("Cookie", Program.COOKIE);
-            Stream myRequestStream = request.GetRequestStream();
-            myRequestStream.Write(postData);
-            myRequestStream.Close();
-            HttpWebResponse webResponse = (HttpWebResponse)request.GetResponse();
-            if (webResponse.ContentEncoding != null
-                && webResponse.ContentEncoding.ToLower() == "gzip") //如果使用了GZip则先解压
-            {
-                using (Stream streamReceive = webResponse.GetResponseStream())
-                {
-                    using (var zipStream =
-                        new GZipInputStream(streamReceive))
-                    {
-                        using (StreamReader sr = new StreamReader(zipStream, Encoding.UTF8))
-                        {
-                            htmlCode = sr.ReadToEnd();
-                        }
-                    }
-                }
-            }
-            else
-            {
-                using (Stream streamReceive = webResponse.GetResponseStream())
-                {
-                    using (StreamReader sr = new StreamReader(streamReceive, Encoding.UTF8))
-                    {
-                        htmlCode = sr.ReadToEnd();
-                    }
-                }
-            }
-
-            if (webResponse != null)
-            {
-                webResponse.Close();
-            }
-            if (request != null)
-            {
-                request.Abort();
-            }
+            request.Content = new ByteArrayContent(postData);
+            var webResponse = await AppHttpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+            Stream myRequestStream = await webResponse.Content.ReadAsStreamAsync();
+            htmlCode = await webResponse.Content.ReadAsStringAsync();
             return htmlCode;
         }
 
-        public static string GetAidByBV(string bv)
+        public static async Task<string> GetAidByBVAsync(string bv)
         {
             string api = $"https://api.bilibili.com/x/web-interface/archive/stat?bvid={bv}";
-            string json = GetWebSource(api);
+            string json = await GetWebSourceAsync(api);
             using var jDoc = JsonDocument.Parse(json);
             string aid = jDoc.RootElement.GetProperty("data").GetProperty("aid").ToString();
             return aid;
         }
 
-        public static string GetEpidBySSId(string ssid)
+        public static async Task<string> GetEpidBySSIdAsync(string ssid)
         {
             string api = $"https://api.bilibili.com/pugv/view/web/season?season_id={ssid}";
-            string json = GetWebSource(api);
+            string json = await GetWebSourceAsync(api);
             using var jDoc = JsonDocument.Parse(json);
             string epId = jDoc.RootElement.GetProperty("data").GetProperty("episodes").EnumerateArray().First().GetProperty("id").ToString();
             return epId;
@@ -316,7 +251,7 @@ namespace BBDown
                 httpRequestMessage.Headers.IfRange = new(lastTime);
                 httpRequestMessage.RequestUri = new(url);
 
-                using var response = (await httpClient.SendAsync(httpRequestMessage, HttpCompletionOption.ResponseHeadersRead)).EnsureSuccessStatusCode();
+                using var response = (await AppHttpClient.SendAsync(httpRequestMessage, HttpCompletionOption.ResponseHeadersRead)).EnsureSuccessStatusCode();
 
                 if (response.StatusCode == HttpStatusCode.OK) // server doesn't response a partial content
                 {
@@ -528,7 +463,7 @@ namespace BBDown
             httpRequestMessage.Headers.Add("User-Agent", "Mozilla/5.0");
             httpRequestMessage.Headers.Add("Cookie", Program.COOKIE);
             httpRequestMessage.RequestUri = new(url);
-            var response = (await httpClient.SendAsync(httpRequestMessage, HttpCompletionOption.ResponseHeadersRead)).EnsureSuccessStatusCode();
+            var response = (await AppHttpClient.SendAsync(httpRequestMessage, HttpCompletionOption.ResponseHeadersRead)).EnsureSuccessStatusCode();
             long totalSizeBytes = response.Content.Headers.ContentLength ?? 0;
 
             return totalSizeBytes;
@@ -592,14 +527,13 @@ namespace BBDown
             return "";
         }
 
-        public static string GetLoginStatus(string oauthKey)
+        public static async Task<string> GetLoginStatusAsync(string oauthKey)
         {
             string queryUrl = "https://passport.bilibili.com/qrcode/getLoginInfo";
-            WebClient webClient = new WebClient();
             NameValueCollection postValues = new NameValueCollection();
             postValues.Add("oauthKey", oauthKey);
             postValues.Add("gourl", "https%3A%2F%2Fwww.bilibili.com%2F");
-            byte[] responseArray = webClient.UploadValues(queryUrl, postValues);
+            byte[] responseArray = await (await AppHttpClient.PostAsync(queryUrl, new FormUrlEncodedContent(postValues.ToDictionary()))).Content.ReadAsByteArrayAsync();
             return Encoding.UTF8.GetString(responseArray);
         }
 
@@ -648,9 +582,19 @@ namespace BBDown
         //https://stackoverflow.com/a/45088333
         public static string ToQueryString(NameValueCollection nameValueCollection)
         {
-            NameValueCollection httpValueCollection = HttpUtility.ParseQueryString(String.Empty);
+            NameValueCollection httpValueCollection = HttpUtility.ParseQueryString(string.Empty);
             httpValueCollection.Add(nameValueCollection);
             return httpValueCollection.ToString();
+        }
+
+        public static Dictionary<string, string> ToDictionary(this NameValueCollection nameValueCollection)
+        {
+            var dict = new Dictionary<string, string>();
+            foreach (var key in nameValueCollection.AllKeys)
+            {
+                dict[key] = nameValueCollection[key];
+            }
+            return dict;
         }
 
         public static string GetMaxQn()
@@ -660,7 +604,7 @@ namespace BBDown
 
         public static NameValueCollection GetTVLoginParms()
         {
-            NameValueCollection sb = new NameValueCollection();
+            NameValueCollection sb = new();
             DateTime now = DateTime.Now;
             string deviceId = GetRandomString(20);
             string buvid = GetRandomString(37);

--- a/BBDown/Directory.Build.props
+++ b/BBDown/Directory.Build.props
@@ -5,6 +5,7 @@
     <IlcFoldIdenticalMethodBodies>true</IlcFoldIdenticalMethodBodies>
     <StaticallyLinked Condition="$(RuntimeIdentifier.StartsWith('win'))">true</StaticallyLinked>
     <TrimMode>Link</TrimMode>
+    <TrimmerDefaultAction>link</TrimmerDefaultAction>
     <NativeAotCompilerVersion>7.0.0-*</NativeAotCompilerVersion>
   </PropertyGroup>
 

--- a/BBDown/IFetcher.cs
+++ b/BBDown/IFetcher.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace BBDown
 {
     interface IFetcher
     {
-        BBDownVInfo Fetch(string id);
+        Task<BBDownVInfo> FetchAsync(string id);
     }
 }

--- a/BBDown/Program.cs
+++ b/BBDown/Program.cs
@@ -74,7 +74,7 @@ namespace BBDown
             public string Aria2cProxy { get; set; } = "";
         }
 
-        public static int Main(params string[] args)
+        public static async Task<int> Main(params string[] args)
         {
             ServicePointManager.DefaultConnectionLimit = 2048;
             ServicePointManager.ServerCertificateValidationCallback = (sender, certificate, chain, errors) =>
@@ -288,7 +288,7 @@ namespace BBDown
                 await DoWorkAsync(myOption);
             });
 
-            return rootCommand.InvokeAsync(args).Result;
+            return await rootCommand.InvokeAsync(args);
         }
 
         private static async Task DoWorkAsync(MyOption myOption)

--- a/BBDown/Program.cs
+++ b/BBDown/Program.cs
@@ -17,6 +17,7 @@ using static BBDown.BBDownMuxer;
 using System.Text;
 using System.Linq;
 using System.Text.Json;
+using System.Net.Http;
 
 namespace BBDown
 {
@@ -175,13 +176,13 @@ namespace BBDown
             rootCommand.TreatUnmatchedTokensAsErrors = true;
 
             //WEB登录
-            loginCommand.Handler = CommandHandler.Create(delegate
+            loginCommand.Handler = CommandHandler.Create(async delegate
             {
                 try
                 {
                     Log("获取登录地址...");
                     string loginUrl = "https://passport.bilibili.com/qrcode/getLoginUrl";
-                    string url = JsonDocument.Parse(GetWebSource(loginUrl)).RootElement.GetProperty("data").GetProperty("url").ToString();
+                    string url = JsonDocument.Parse(await GetWebSourceAsync(loginUrl)).RootElement.GetProperty("data").GetProperty("url").ToString();
                     string oauthKey = GetQueryString("oauthKey", url);
                     //Log(oauthKey);
                     //Log(url);
@@ -195,8 +196,8 @@ namespace BBDown
                     Log("生成二维码成功：qrcode.png, 请打开并扫描");
                     while (true)
                     {
-                        Thread.Sleep(1000);
-                        string w = GetLoginStatus(oauthKey);
+                        await Task.Delay(1000);
+                        string w = await GetLoginStatusAsync(oauthKey);
                         string data = JsonDocument.Parse(w).RootElement.GetProperty("data").ToString();
                         if (data == "-2")
                         {
@@ -230,7 +231,7 @@ namespace BBDown
             });
 
             //TV登录
-            loginTVCommand.Handler = CommandHandler.Create(delegate
+            loginTVCommand.Handler = CommandHandler.Create(async delegate
             {
                 try
                 {
@@ -238,8 +239,7 @@ namespace BBDown
                     string pollUrl = "https://passport.bilibili.com/x/passport-tv-login/qrcode/poll";
                     var parms = GetTVLoginParms();
                     Log("获取登录地址...");
-                    WebClient webClient = new WebClient();
-                    byte[] responseArray = webClient.UploadValues(loginUrl, parms);
+                    byte[] responseArray = await (await AppHttpClient.PostAsync(loginUrl, new FormUrlEncodedContent(parms.ToDictionary()))).Content.ReadAsByteArrayAsync();
                     string web = Encoding.UTF8.GetString(responseArray);
                     string url = JsonDocument.Parse(web).RootElement.GetProperty("data").GetProperty("url").ToString();
                     string authCode = JsonDocument.Parse(web).RootElement.GetProperty("data").GetProperty("auth_code").ToString();
@@ -256,8 +256,8 @@ namespace BBDown
                     parms.Add("sign", GetSign(ToQueryString(parms)));
                     while (true)
                     {
-                        Thread.Sleep(1000);
-                        responseArray = webClient.UploadValues(pollUrl, parms);
+                        await Task.Delay(1000);
+                        responseArray = await (await AppHttpClient.PostAsync(pollUrl, new FormUrlEncodedContent(parms.ToDictionary()))).Content.ReadAsByteArrayAsync();
                         web = Encoding.UTF8.GetString(responseArray);
                         string code = JsonDocument.Parse(web).RootElement.GetProperty("code").ToString();
                         if (code == "86038")
@@ -432,7 +432,7 @@ namespace BBDown
                 {
                     fetcher = new BBDownSpaceVideoFetcher();
                 }
-                var vInfo = fetcher.Fetch(aidOri);
+                var vInfo = await fetcher.FetchAsync(aidOri);
                 string title = vInfo.Title;
                 string desc = vInfo.Desc;
                 string pic = vInfo.Pic;
@@ -511,18 +511,20 @@ namespace BBDown
                         {
                             Log("下载封面...");
                             LogDebug("下载：{0}", pic);
-                            new WebClient().DownloadFile(pic, $"{p.aid}/{p.aid}.jpg");
+                            await using var response = await AppHttpClient.GetStreamAsync(pic);
+                            await using var fs = new FileStream($"{p.aid}/{p.aid}.jpg", FileMode.OpenOrCreate);
+                            await response.CopyToAsync(fs);
                         }
 
                         if (!skipSubtitle)
                         {
                             LogDebug("获取字幕...");
-                            subtitleInfo = BBDownSubUtil.GetSubtitles(p.aid, p.cid, p.epid, intlApi);
+                            subtitleInfo = await BBDownSubUtil.GetSubtitlesAsync(p.aid, p.cid, p.epid, intlApi);
                             foreach (Subtitle s in subtitleInfo)
                             {
                                 Log($"下载字幕 {s.lan} => {BBDownSubUtil.SubDescDic[s.lan]}...");
                                 LogDebug("下载：{0}", s.url);
-                                BBDownSubUtil.SaveSubtitle(s.url, s.path);
+                                await BBDownSubUtil.SaveSubtitleAsync(s.url, s.path);
                                 if (subOnly && File.Exists(s.path) && File.ReadAllText(s.path) != "")
                                 {
                                     string _indexStr = p.index.ToString("0".PadRight(pagesInfo.OrderByDescending(_p => _p.index).First().index.ToString().Length, '0'));
@@ -549,7 +551,7 @@ namespace BBDown
                     }
 
                     //调用解析
-                    (webJsonStr, videoTracks, audioTracks, clips, dfns) = ExtractTracks(onlyHevc, onlyAvc, aidOri, p.aid, p.cid, p.epid, tvApi, intlApi, appApi);
+                    (webJsonStr, videoTracks, audioTracks, clips, dfns) = await ExtractTracksAsync(onlyHevc, onlyAvc, aidOri, p.aid, p.cid, p.epid, tvApi, intlApi, appApi);
 
                     //File.WriteAllText($"debug.json", JObject.Parse(webJson).ToString());
                     
@@ -717,7 +719,7 @@ namespace BBDown
                             if (vIndex > dfns.Count || vIndex < 0) vIndex = 0;
                             Console.ResetColor();
                             //重新解析
-                            (webJsonStr, videoTracks, audioTracks, clips, dfns) = ExtractTracks(onlyHevc, onlyAvc, aidOri, p.aid, p.cid, p.epid, tvApi, intlApi, appApi, dfns[vIndex]);
+                            (webJsonStr, videoTracks, audioTracks, clips, dfns) = await ExtractTracksAsync(onlyHevc, onlyAvc, aidOri, p.aid, p.cid, p.epid, tvApi, intlApi, appApi, dfns[vIndex]);
                             flag = true;
                             videoTracks.Clear();
                             goto reParse;


### PR DESCRIPTION
- Upgrade to .NET 6
- Replace all WebClient with HttpClient
- Remove all blocking invocations
- Shrink size by 20%