### PR TITLE
Add faststart for ffmpeg

### DIFF
--- a/BBDown/BBDownMuxer.cs
+++ b/BBDown/BBDownMuxer.cs
@@ -129,6 +129,7 @@ namespace BBDown
                  (audioOnly ? " -vn " : "") + (videoOnly ? " -an " : "") +
                  $"-c copy " +
                  (subs != null ? " -c:s mov_text " : "") +
+                 "-movflags faststart " +
                  $"\"{outPath}\"";
             LogDebug("ffmpeg命令：{0}", arguments);
             return RunExe("ffmpeg", arguments);


### PR DESCRIPTION
-movflags faststart 将moov前移，使MP4文件更适合网络串流，MP4Box默认采用此行为。