### PR TITLE
Revert "Fix ilc version"

### DIFF
--- a/BBDown/Directory.Build.props
+++ b/BBDown/Directory.Build.props
@@ -6,7 +6,7 @@
     <StaticallyLinked Condition="$(RuntimeIdentifier.StartsWith('win'))">true</StaticallyLinked>
     <TrimMode>Link</TrimMode>
     <TrimmerDefaultAction>link</TrimmerDefaultAction>
-    <NativeAotCompilerVersion>7.0.0-preview.2.*</NativeAotCompilerVersion>
+    <NativeAotCompilerVersion>7.0.0-*</NativeAotCompilerVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Reverts nilaoda/BBDown#275

Ilc compling against SIM should work now in newer package. See https://github.com/dotnet/runtime/pull/66084. 