### PR TITLE
fix: 命令行二维码颜色错误问题

### DIFF
--- a/BBDown/ConsoleQRCode.cs
+++ b/BBDown/ConsoleQRCode.cs
@@ -24,9 +24,10 @@ namespace BBDown
             {
                 for (int x = 0; x < QrCodeData.ModuleMatrix[y].Count; x++)
                 {
-                    Console.BackgroundColor = QrCodeData.ModuleMatrix[y][x] ? ConsoleColor.White : ConsoleColor.Black;
-                    Console.Write("  ");
+                    Console.ForegroundColor = QrCodeData.ModuleMatrix[y][x] ? darkColor : lightColor;
+                    Console.Write("██");
                 }
+                Console.BackgroundColor = darkColor;
                 Console.WriteLine("");
             }
             Console.BackgroundColor = previousBackColor;


### PR DESCRIPTION
before:
![图片](https://user-images.githubusercontent.com/10357394/170176072-71400491-e527-4a4e-8379-643280c5a86d.png)

after:

![QQ截图20220525114945](https://user-images.githubusercontent.com/10357394/170176107-032d5bb5-f50e-4094-972f-83b171bcb880.png)
![QQ截图20220525115016](https://user-images.githubusercontent.com/10357394/170176113-39f4db3a-820b-4cab-84c5-8b9f1cac421f.png)
![QQ截图20220525115156](https://user-images.githubusercontent.com/10357394/170176115-f1135403-cda3-4988-b99a-3174dee39de9.png)
