### PR TITLE
fix(配置文件): 修复配置文件无法正确读取string参数

### DIFF
--- a/BBDown/Program.cs
+++ b/BBDown/Program.cs
@@ -332,7 +332,10 @@ namespace BBDown
                 if (File.Exists(configPath))
                 {
                     Log($"加载配置文件: {configPath}");
-                    var configArgs = File.ReadAllLines(configPath).Where(s => !string.IsNullOrEmpty(s) && !s.StartsWith("#")).Select(s => s.Trim().Trim('\"'));
+                    var configArgs = File
+                        .ReadAllLines(configPath)
+                        .Where(s => !string.IsNullOrEmpty(s) && !s.StartsWith("#"))
+                        .SelectMany(s => s.Split(' ').Where(s => !string.IsNullOrEmpty(s)).Select(s => s.Trim('\"')));
                     var configArgsResult = rootCommand.Parse(configArgs.ToArray());
                     foreach (var item in configArgsResult.CommandResult.Children)
                     {

--- a/BBDown/Program.cs
+++ b/BBDown/Program.cs
@@ -335,7 +335,17 @@ namespace BBDown
                     var configArgs = File
                         .ReadAllLines(configPath)
                         .Where(s => !string.IsNullOrEmpty(s) && !s.StartsWith("#"))
-                        .SelectMany(s => s.Split(' ').Where(s => !string.IsNullOrEmpty(s)).Select(s => s.Trim('\"')));
+                        .SelectMany(s => {
+                                var trimLine = s.Trim();
+                                if (trimLine.IndexOf('-') == 0 && trimLine.IndexOf(' ') != -1) {  
+                                    var spaceIndex = trimLine.IndexOf(' ');
+                                    var paramsGroup = new String[] { trimLine.Substring(0,spaceIndex), trimLine.Substring(spaceIndex) };
+                                    return paramsGroup.Where(s => !string.IsNullOrEmpty(s)).Select(s => s.Trim(' ').Trim('\"'));
+                                } else {
+                                    return new String[] {trimLine.Trim('\"')};
+                                }                    
+                            }
+                        );
                     var configArgsResult = rootCommand.Parse(configArgs.ToArray());
                     foreach (var item in configArgsResult.CommandResult.Children)
                     {


### PR DESCRIPTION
## 解决了什么问题？

目前的版本读取BBDown.config配置文件，比如

BBDown.config文件
```
--debug

-app

--encoding-priority hevc,avc,av1
```

--encoding-priority 无法正常生效 

通过pr修复了这个问题（string option都无法通过配置文件生效）

## 原因和解决办法

主要是由于rootCommand.Parse这个api的特性导致，当不走配置文件，通过命令行获取args
假设命令行输入是：BBdown.exe https://www.bilibili.com/video/BV1Mv4y1N7yJ --encoding-priority hevc,avc,av1 -app
params string[] args 相当于下面的数组
```c#
var string[] argsArr = ["https://www.bilibili.com/video/BV1Mv4y1N7yJ","--encoding-priority","hevc,avc,av1","-app"]
var commandLineResult = rootCommand.Parse(args);
```
 其中--encoding-priority和hevc,avc,av1是分开的,rootCommand.Parse解析正常

当走配置文件时，这个数组的切分是由File.ReadAllLines完成的，其中--encoding-priority hevc,avc,av1是一行，只形成了一个item，而对于rootCommand.Parse来说，没法正确解析--encoding-priority hevc,avc,av1这样一整个的输入。
```c#
var configArgs = File.ReadAllLines(configPath).Where(s => !string.IsNullOrEmpty(s) && !s.StartsWith("#")).Select(s => s.Trim().Trim('\"'));
```
解决思路是通过拆分--encoding-priority hevc,avc,av1到2个item进行解决

