### PR TITLE
feat(配置文件): 增加上传者名称，mid参数

### DIFF
--- a/BBDown.Core/Entity/Entity.cs
+++ b/BBDown.Core/Entity/Entity.cs
@@ -17,6 +17,8 @@ namespace BBDown.Core.Entity
             public string res;
             public string cover;
             public string desc;
+            public string ownerName;
+            public string ownerMid;
             public List<ViewPoint> points = new List<ViewPoint>();
 
             public Page(int index, string aid, string cid, string epid, string title, int dur, string res)
@@ -55,6 +57,21 @@ namespace BBDown.Core.Entity
                 this.desc = desc;
             }
 
+            public Page(int index, string aid, string cid, string epid, string title, int dur, string res, string cover, string desc, string ownerName, string ownerMid)
+            {
+                this.aid = aid;
+                this.index = index;
+                this.cid = cid;
+                this.epid = epid;
+                this.title = title;
+                this.dur = dur;
+                this.res = res;
+                this.cover = cover;
+                this.desc = desc;
+                this.ownerName = ownerName;
+                this.ownerMid = ownerMid;
+            }
+
             public Page(int index, Page page)
             {
                 this.index = index;
@@ -65,6 +82,8 @@ namespace BBDown.Core.Entity
                 this.dur = page.dur;
                 this.res = page.res;
                 this.cover = page.cover;
+                this.ownerName = page.ownerName;
+                this.ownerMid = page.ownerMid;
             }
 
             public override bool Equals(object obj)

--- a/BBDown.Core/Fetcher/FavListFetcher.cs
+++ b/BBDown.Core/Fetcher/FavListFetcher.cs
@@ -83,7 +83,9 @@ namespace BBDown.Core.Fetcher
                         m.GetProperty("duration").GetInt32(),
                         "",
                         m.GetProperty("cover").ToString(),
-                        m.GetProperty("intro").ToString());
+                        m.GetProperty("intro").ToString(),
+                        m.GetProperty("upper").GetProperty("name").ToString(),
+                        m.GetProperty("upper").GetProperty("mid").ToString());
                     if (!pagesInfo.Contains(p)) pagesInfo.Add(p);
                 }
             }

--- a/BBDown.Core/Fetcher/MediaListFetcher.cs
+++ b/BBDown.Core/Fetcher/MediaListFetcher.cs
@@ -44,6 +44,8 @@ namespace BBDown.Core.Fetcher
                 {
                     var pageCount = m.GetProperty("page").GetInt32();
                     var desc = m.GetProperty("intro").GetString();
+                    var ownerName = m.GetProperty("upper").GetProperty("name").ToString();
+                    var ownerMid = m.GetProperty("upper").GetProperty("mid").ToString();
                     foreach (var page in m.GetProperty("pages").EnumerateArray())
                     {
                         Page p = new Page(index++,
@@ -54,7 +56,9 @@ namespace BBDown.Core.Fetcher
                         page.GetProperty("duration").GetInt32(),
                         page.GetProperty("dimension").GetProperty("width").ToString() + "x" + page.GetProperty("dimension").GetProperty("height").ToString(),
                         m.GetProperty("cover").ToString(),
-                        desc);
+                        desc,
+                        ownerName,
+                        ownerMid);
                         if (!pagesInfo.Contains(p)) pagesInfo.Add(p);
                         else index--;
                     }

--- a/BBDown.Core/Fetcher/NormalInfoFetcher.cs
+++ b/BBDown.Core/Fetcher/NormalInfoFetcher.cs
@@ -22,6 +22,9 @@ namespace BBDown.Core.Fetcher
             string title = data.GetProperty("title").ToString();
             string desc = data.GetProperty("desc").ToString();
             string pic = data.GetProperty("pic").ToString();
+            var owner = data.GetProperty("owner");
+            string ownerMid = owner.GetProperty("mid").ToString();
+            string ownerName = owner.GetProperty("name").ToString();
             string pubTime = data.GetProperty("pubdate").ToString();
             pubTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc).AddSeconds(Convert.ToDouble(pubTime)).ToLocalTime().ToString();
             bool bangumi = false;
@@ -36,7 +39,12 @@ namespace BBDown.Core.Fetcher
                     "", //epid
                     page.GetProperty("part").ToString().Trim(),
                     page.GetProperty("duration").GetInt32(),
-                    page.GetProperty("dimension").GetProperty("width").ToString() + "x" + page.GetProperty("dimension").GetProperty("height").ToString());
+                    page.GetProperty("dimension").GetProperty("width").ToString() + "x" + page.GetProperty("dimension").GetProperty("height").ToString(),
+                    "",
+                    "",
+                    ownerName,
+                    ownerMid
+                    );
                 pagesInfo.Add(p);
             }
 

--- a/BBDown.Core/Fetcher/SeriesListFetcher.cs
+++ b/BBDown.Core/Fetcher/SeriesListFetcher.cs
@@ -46,6 +46,8 @@ namespace BBDown.Core.Fetcher
                 {
                     var pageCount = m.GetProperty("page").GetInt32();
                     var desc = m.GetProperty("intro").GetString();
+                    var ownerName = m.GetProperty("upper").GetProperty("name").ToString();
+                    var ownerMid = m.GetProperty("upper").GetProperty("mid").ToString();
                     foreach (var page in m.GetProperty("pages").EnumerateArray())
                     {
                         Page p = new Page(index++,
@@ -56,7 +58,9 @@ namespace BBDown.Core.Fetcher
                         page.GetProperty("duration").GetInt32(),
                         page.GetProperty("dimension").GetProperty("width").ToString() + "x" + page.GetProperty("dimension").GetProperty("height").ToString(),
                         m.GetProperty("cover").ToString(),
-                        desc);
+                        desc,
+                        ownerName,
+                        ownerMid);
                         if (!pagesInfo.Contains(p)) pagesInfo.Add(p);
                         else index--;
                     }

--- a/BBDown/Program.cs
+++ b/BBDown/Program.cs
@@ -219,7 +219,9 @@ namespace BBDown
                     $"<videoCodecs>: 视频编码\r\n" +
                     $"<videoBandwidth>: 视频码率\r\n" +
                     $"<audioCodecs>: 音频编码\r\n" +
-                    $"<audioBandwidth>: 音频码率\r\n\r\n" +
+                    $"<audioBandwidth>: 音频码率\r\n" +
+                    $"<ownerName>: 上传者名称\r\n" +
+                    $"<ownerMid>: 上传者mid\r\n\r\n" +
                     $"默认为: {SinglePageDefaultSavePath}\r\n"),
                 new Option<string>(
                     new string[]{ "--multi-file-pattern", "-M"},
@@ -1209,6 +1211,8 @@ namespace BBDown
                     "pageTitle" => GetValidFileName(p.title, filterSlash: true),
                     "aid" => p.aid,
                     "cid" => p.cid,
+                    "ownerName" => p.ownerName == null ? "" : GetValidFileName(p.ownerName, filterSlash: true),
+                    "ownerMid" => p.ownerMid == null ? "" : p.ownerMid,
                     "dfn" => videoTrack == null ? "" : videoTrack.dfn,
                     "res" => videoTrack == null ? "" : videoTrack.res,
                     "fps" => videoTrack == null ? "" : videoTrack.fps,

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Options:
                                                  <videoBandwidth>: 视频码率
                                                  <audioCodecs>: 音频编码
                                                  <audioBandwidth>: 音频码率
+                                                 <ownerName>: 上传者名称
+                                                 <ownerMid>: 上传者mid
 
                                                  默认为: <videoTitle>
 
@@ -174,6 +176,8 @@ Commands:
 `<videoBandwidth>`|视频码率
 `<audioCodecs>`|音频编码
 `<audioBandwidth>`|音频码率
+`<ownerName>`|上传者名称(下载番剧时，该值为"")
+`<ownerMid>`|上传者mid(下载番剧时，该值为"")
 
 </details>
 


### PR DESCRIPTION
文件名称自定义，新增加上传者相关的内置参数，ownerName和ownerMid。

目前覆盖
MediaListFetcher     播放列表支持
NormalInfoFetcher  普通视频支持
SeriesListFetcher  合辑列表支持
FavListFetcher   收藏夹支持

其他
SpaceVideoFetcher  空间合集下载暂不支持
BangumiInfoFetcher  番剧没有上传者，不支持
IntlBangumiInfoFetcher  番剧没有上传者，不支持

唯一不确定的是，我不太清楚 CheeseInfoFetcher 这个是处理哪种类型的视频，不知道需不需要补齐上传者信息


