### PR TITLE
feat: 统一文件命名参数

### DIFF
--- a/BBDown.Core/Entity/Entity.cs
+++ b/BBDown.Core/Entity/Entity.cs
@@ -12,58 +12,51 @@ namespace BBDown.Core.Entity
             public string aid;
             public string cid;
             public string epid;
-            public string title;
+            public string videoTitle;
+            public string pageTitle;
             public int dur;
             public string res;
             public string cover;
             public string desc;
             public string ownerName;
             public string ownerMid;
+            public bool isSingleP;
             public List<ViewPoint> points = new List<ViewPoint>();
 
-            public Page(int index, string aid, string cid, string epid, string title, int dur, string res)
+            public Page(int index, string aid, string cid, string epid, string videoTitle, string pageTitle, int dur, string res)
             {
                 this.aid = aid;
                 this.index = index;
                 this.cid = cid;
                 this.epid = epid;
-                this.title = title;
+                this.videoTitle = videoTitle;
+                this.pageTitle = pageTitle;
                 this.dur = dur;
                 this.res = res;
             }
 
-            public Page(int index, string aid, string cid, string epid, string title, int dur, string res, string cover)
+            public Page(int index, string aid, string cid, string epid, string videoTitle, string pageTitle, int dur, string res, string cover, string desc)
             {
                 this.aid = aid;
                 this.index = index;
                 this.cid = cid;
                 this.epid = epid;
-                this.title = title;
-                this.dur = dur;
-                this.res = res;
-                this.cover = cover;
-            }
-
-            public Page(int index, string aid, string cid, string epid, string title, int dur, string res, string cover, string desc)
-            {
-                this.aid = aid;
-                this.index = index;
-                this.cid = cid;
-                this.epid = epid;
-                this.title = title;
+                this.videoTitle = videoTitle;
+                this.pageTitle = pageTitle;
                 this.dur = dur;
                 this.res = res;
                 this.cover = cover;
                 this.desc = desc;
             }
 
-            public Page(int index, string aid, string cid, string epid, string title, int dur, string res, string cover, string desc, string ownerName, string ownerMid)
+            public Page(int index, string aid, string cid, string epid, string videoTitle, string pageTitle, int dur, string res, string cover, string desc, string ownerName, string ownerMid)
             {
                 this.aid = aid;
                 this.index = index;
                 this.cid = cid;
                 this.epid = epid;
-                this.title = title;
+                this.videoTitle = videoTitle;
+                this.pageTitle = pageTitle;
                 this.dur = dur;
                 this.res = res;
                 this.cover = cover;
@@ -78,10 +71,12 @@ namespace BBDown.Core.Entity
                 this.aid = page.aid;
                 this.cid = page.cid;
                 this.epid = page.epid;
-                this.title = page.title;
+                this.videoTitle = page.videoTitle;
+                this.pageTitle = page.pageTitle;
                 this.dur = page.dur;
                 this.res = page.res;
                 this.cover = page.cover;
+                this.desc = page.desc;
                 this.ownerName = page.ownerName;
                 this.ownerMid = page.ownerMid;
             }

--- a/BBDown.Core/Entity/Entity.cs
+++ b/BBDown.Core/Entity/Entity.cs
@@ -49,7 +49,7 @@ namespace BBDown.Core.Entity
                 this.desc = desc;
             }
 
-            public Page(int index, string aid, string cid, string epid, string videoTitle, string pageTitle, int dur, string res, string cover, string desc, string ownerName, string ownerMid)
+            public Page(int index, string aid, string cid, string epid, string videoTitle, string pageTitle, int dur, string res, string cover, string desc, string ownerName, string ownerMid, bool isSingleP)
             {
                 this.aid = aid;
                 this.index = index;
@@ -63,6 +63,7 @@ namespace BBDown.Core.Entity
                 this.desc = desc;
                 this.ownerName = ownerName;
                 this.ownerMid = ownerMid;
+                this.isSingleP = isSingleP;
             }
 
             public Page(int index, Page page)
@@ -79,6 +80,7 @@ namespace BBDown.Core.Entity
                 this.desc = page.desc;
                 this.ownerName = page.ownerName;
                 this.ownerMid = page.ownerMid;
+                this.isSingleP = page.isSingleP;
             }
 
             public override bool Equals(object obj)

--- a/BBDown.Core/Entity/VInfo.cs
+++ b/BBDown.Core/Entity/VInfo.cs
@@ -13,19 +13,9 @@ namespace BBDown.Core.Entity
         private string index;
 
         /// <summary>
-        /// 视频标题
+        /// 合集标题/收藏夹标题
         /// </summary>
         private string title;
-
-        /// <summary>
-        /// 视频描述
-        /// </summary>
-        private string desc;
-
-        /// <summary>
-        /// 视频封面
-        /// </summary>
-        private string pic;
 
         /// <summary>
         /// 视频发布时间
@@ -34,6 +24,9 @@ namespace BBDown.Core.Entity
 
         private bool isBangumi;
         private bool isCheese;
+        private bool isFavList;
+        private bool isSeriesList;
+        private bool isMediaList;
 
         /// <summary>
         /// 番剧是否完结
@@ -46,11 +39,12 @@ namespace BBDown.Core.Entity
         private List<Page> pagesInfo;
 
         public string Title { get => title; set => title = value; }
-        public string Desc { get => desc; set => desc = value; }
-        public string Pic { get => pic; set => pic = value; }
         public string PubTime { get => pubTime; set => pubTime = value; }
         public bool IsBangumi { get => isBangumi; set => isBangumi = value; }
         public bool IsCheese { get => isCheese; set => isCheese = value; }
+        public bool IsFavList { get => isFavList; set => isFavList = value; }
+        public bool IsSeriesList { get => isSeriesList; set => isSeriesList = value; }
+        public bool IsMediaList { get => isMediaList; set => isMediaList = value; }
         public bool IsBangumiEnd { get => isBangumiEnd; set => isBangumiEnd = value; }
         public string Index { get => index; set => index = value; }
         public List<Page> PagesInfo { get => pagesInfo; set => pagesInfo = value; }

--- a/BBDown.Core/Fetcher/BangumiInfoFetcher.cs
+++ b/BBDown.Core/Fetcher/BangumiInfoFetcher.cs
@@ -62,8 +62,13 @@ namespace BBDown.Core.Fetcher
                     page.GetProperty("aid").ToString(),
                     page.GetProperty("cid").ToString(),
                     page.GetProperty("id").ToString(),
+                    title.Trim(),
                     _title,
-                    0, res);
+                    0,
+                    res,
+                    cover,
+                    desc.Trim()
+                    );
                 if (p.epid == id) index = p.index.ToString();
                 pagesInfo.Add(p);
             }
@@ -71,8 +76,6 @@ namespace BBDown.Core.Fetcher
 
             var info = new VInfo();
             info.Title = title.Trim();
-            info.Desc = desc.Trim();
-            info.Pic = cover;
             info.PubTime = pubTime;
             info.PagesInfo = pagesInfo;
             info.IsBangumi = true;

--- a/BBDown.Core/Fetcher/CheeseInfoFetcher.cs
+++ b/BBDown.Core/Fetcher/CheeseInfoFetcher.cs
@@ -40,7 +40,8 @@ namespace BBDown.Core.Fetcher
                     cover,
                     desc.Trim(),
                     ownerName,
-                    ownerMid);
+                    ownerMid,
+                    false);
                 if (p.epid == id) index = p.index.ToString();
                 pagesInfo.Add(p);
             }

--- a/BBDown.Core/Fetcher/CheeseInfoFetcher.cs
+++ b/BBDown.Core/Fetcher/CheeseInfoFetcher.cs
@@ -33,11 +33,12 @@ namespace BBDown.Core.Fetcher
                     page.GetProperty("aid").ToString(),
                     page.GetProperty("cid").ToString(),
                     page.GetProperty("id").ToString(),
+                    title.Trim(),
                     page.GetProperty("title").ToString().Trim(),
                     page.GetProperty("duration").GetInt32(),
                     "",
-                    "",
-                    "",
+                    cover,
+                    desc.Trim(),
                     ownerName,
                     ownerMid);
                 if (p.epid == id) index = p.index.ToString();
@@ -48,8 +49,6 @@ namespace BBDown.Core.Fetcher
 
             var info = new VInfo();
             info.Title = title.Trim();
-            info.Desc = desc.Trim();
-            info.Pic = cover;
             info.PubTime = pubTime;
             info.PagesInfo = pagesInfo;
             info.IsBangumi = true;

--- a/BBDown.Core/Fetcher/FavListFetcher.cs
+++ b/BBDown.Core/Fetcher/FavListFetcher.cs
@@ -61,42 +61,21 @@ namespace BBDown.Core.Fetcher
             foreach (var m in medias)
             {
                 var pageCount = m.GetProperty("page").GetInt32();
-                if (pageCount > 1)
+                var tmpInfo = await new NormalInfoFetcher().FetchAsync(m.GetProperty("id").ToString());
+                foreach (var item in tmpInfo.PagesInfo)
                 {
-                    var tmpInfo = await new NormalInfoFetcher().FetchAsync(m.GetProperty("id").ToString());
-                    foreach (var item in tmpInfo.PagesInfo)
-                    {
-                        Page p = new Page(index++, item);
-                        p.title = m.GetProperty("title").ToString() + $"_P{item.index}_{item.title}";
-                        p.cover = tmpInfo.Pic;
-                        p.desc = m.GetProperty("intro").ToString();
-                        if (!pagesInfo.Contains(p)) pagesInfo.Add(p);
-                    }
-                }
-                else
-                {
-                    Page p = new Page(index++,
-                        m.GetProperty("id").ToString(),
-                        m.GetProperty("ugc").GetProperty("first_cid").ToString(),
-                        "", //epid
-                        m.GetProperty("title").ToString(),
-                        m.GetProperty("duration").GetInt32(),
-                        "",
-                        m.GetProperty("cover").ToString(),
-                        m.GetProperty("intro").ToString(),
-                        m.GetProperty("upper").GetProperty("name").ToString(),
-                        m.GetProperty("upper").GetProperty("mid").ToString());
+                    Page p = new Page(index++, item);
                     if (!pagesInfo.Contains(p)) pagesInfo.Add(p);
                 }
             }
 
             var info = new VInfo();
-            info.Title = title.Trim();
-            info.Desc = intro.Trim();
-            info.Pic = "";
+            // 收藏夹标题
+            info.Title = title;
             info.PubTime = pubTime;
             info.PagesInfo = pagesInfo;
             info.IsBangumi = false;
+            info.IsFavList = true;
 
             return info;
         }

--- a/BBDown.Core/Fetcher/IntlBangumiInfoFetcher.cs
+++ b/BBDown.Core/Fetcher/IntlBangumiInfoFetcher.cs
@@ -103,8 +103,12 @@ namespace BBDown.Core.Fetcher
                     page.GetProperty("aid").ToString(),
                     page.GetProperty("cid").ToString(),
                     page.GetProperty("id").ToString(),
+                    title.Trim(),
                     _title,
-                    0, res);
+                    0,
+                    res,
+                    cover,
+                    desc.Trim());
                 if (p.epid == id) index = p.index.ToString();
                 pagesInfo.Add(p);
             }
@@ -112,8 +116,6 @@ namespace BBDown.Core.Fetcher
 
             var info = new VInfo();
             info.Title = title.Trim();
-            info.Desc = desc.Trim();
-            info.Pic = cover;
             info.PubTime = pubTime;
             info.PagesInfo = pagesInfo;
             info.IsBangumi = true;

--- a/BBDown.Core/Fetcher/MediaListFetcher.cs
+++ b/BBDown.Core/Fetcher/MediaListFetcher.cs
@@ -52,7 +52,8 @@ namespace BBDown.Core.Fetcher
                         m.GetProperty("id").ToString(),
                         page.GetProperty("id").ToString(),
                         "", //epid
-                        pageCount == 1 ? m.GetProperty("title").ToString() : $"{m.GetProperty("title").ToString()}_P{page.GetProperty("page").ToString()}_{page.GetProperty("title")}", //单P使用外层标题 多P则拼接内层子标题
+                        m.GetProperty("title").ToString(),
+                        page.GetProperty("title").ToString(),
                         page.GetProperty("duration").GetInt32(),
                         page.GetProperty("dimension").GetProperty("width").ToString() + "x" + page.GetProperty("dimension").GetProperty("height").ToString(),
                         m.GetProperty("cover").ToString(),
@@ -68,8 +69,6 @@ namespace BBDown.Core.Fetcher
 
             var info = new VInfo();
             info.Title = listTitle.Trim();
-            info.Desc = intro.Trim();
-            info.Pic = "";
             info.PubTime = pubTime;
             info.PagesInfo = pagesInfo;
             info.IsBangumi = false;

--- a/BBDown.Core/Fetcher/MediaListFetcher.cs
+++ b/BBDown.Core/Fetcher/MediaListFetcher.cs
@@ -46,7 +46,9 @@ namespace BBDown.Core.Fetcher
                     var desc = m.GetProperty("intro").GetString();
                     var ownerName = m.GetProperty("upper").GetProperty("name").ToString();
                     var ownerMid = m.GetProperty("upper").GetProperty("mid").ToString();
-                    foreach (var page in m.GetProperty("pages").EnumerateArray())
+                    var pageList = m.GetProperty("pages").EnumerateArray().ToList();
+                    var isSingleP = pageList.Count > 1 ? false : true; 
+                    foreach (var page in pageList)
                     {
                         Page p = new Page(index++,
                         m.GetProperty("id").ToString(),
@@ -59,7 +61,8 @@ namespace BBDown.Core.Fetcher
                         m.GetProperty("cover").ToString(),
                         desc,
                         ownerName,
-                        ownerMid);
+                        ownerMid,
+                        isSingleP);
                         if (!pagesInfo.Contains(p)) pagesInfo.Add(p);
                         else index--;
                     }

--- a/BBDown.Core/Fetcher/NormalInfoFetcher.cs
+++ b/BBDown.Core/Fetcher/NormalInfoFetcher.cs
@@ -37,11 +37,12 @@ namespace BBDown.Core.Fetcher
                     id,
                     page.GetProperty("cid").ToString(),
                     "", //epid
+                    title.Trim(),
                     page.GetProperty("part").ToString().Trim(),
                     page.GetProperty("duration").GetInt32(),
                     page.GetProperty("dimension").GetProperty("width").ToString() + "x" + page.GetProperty("dimension").GetProperty("height").ToString(),
-                    "",
-                    "",
+                    pic,
+                    desc,
                     ownerName,
                     ownerMid
                     );
@@ -65,8 +66,6 @@ namespace BBDown.Core.Fetcher
 
             var info = new VInfo();
             info.Title = title.Trim();
-            info.Desc = desc.Trim();
-            info.Pic = pic;
             info.PubTime = pubTime;
             info.PagesInfo = pagesInfo;
             info.IsBangumi = bangumi;

--- a/BBDown.Core/Fetcher/NormalInfoFetcher.cs
+++ b/BBDown.Core/Fetcher/NormalInfoFetcher.cs
@@ -31,6 +31,7 @@ namespace BBDown.Core.Fetcher
 
             var pages = data.GetProperty("pages").EnumerateArray().ToList();
             List<Page> pagesInfo = new List<Page>();
+            var isSingleP = pages.Count > 1 ? false : true;
             foreach (var page in pages)
             {
                 Page p = new Page(page.GetProperty("page").GetInt32(),
@@ -44,7 +45,8 @@ namespace BBDown.Core.Fetcher
                     pic,
                     desc,
                     ownerName,
-                    ownerMid
+                    ownerMid,
+                    isSingleP
                     );
                 pagesInfo.Add(p);
             }

--- a/BBDown.Core/Fetcher/SeriesListFetcher.cs
+++ b/BBDown.Core/Fetcher/SeriesListFetcher.cs
@@ -54,7 +54,8 @@ namespace BBDown.Core.Fetcher
                         m.GetProperty("id").ToString(),
                         page.GetProperty("id").ToString(),
                         "", //epid
-                        pageCount == 1 ? m.GetProperty("title").ToString() : $"{m.GetProperty("title").ToString()}_P{page.GetProperty("page").ToString()}_{page.GetProperty("title")}", //单P使用外层标题 多P则拼接内层子标题
+                        m.GetProperty("title").ToString(),
+                        page.GetProperty("title").ToString(),
                         page.GetProperty("duration").GetInt32(),
                         page.GetProperty("dimension").GetProperty("width").ToString() + "x" + page.GetProperty("dimension").GetProperty("height").ToString(),
                         m.GetProperty("cover").ToString(),
@@ -69,12 +70,12 @@ namespace BBDown.Core.Fetcher
             }
 
             var info = new VInfo();
+            // 合集标题
             info.Title = listTitle.Trim();
-            info.Desc = intro.Trim();
-            info.Pic = "";
             info.PubTime = pubTime;
             info.PagesInfo = pagesInfo;
             info.IsBangumi = false;
+            info.IsSeriesList = true;
 
             return info;
         }

--- a/BBDown.Core/Fetcher/SeriesListFetcher.cs
+++ b/BBDown.Core/Fetcher/SeriesListFetcher.cs
@@ -48,7 +48,9 @@ namespace BBDown.Core.Fetcher
                     var desc = m.GetProperty("intro").GetString();
                     var ownerName = m.GetProperty("upper").GetProperty("name").ToString();
                     var ownerMid = m.GetProperty("upper").GetProperty("mid").ToString();
-                    foreach (var page in m.GetProperty("pages").EnumerateArray())
+                    var pageList = m.GetProperty("pages").EnumerateArray().ToList();
+                    var isSingleP = pageList.Count > 1 ? false : true; 
+                    foreach (var page in pageList)
                     {
                         Page p = new Page(index++,
                         m.GetProperty("id").ToString(),
@@ -61,7 +63,8 @@ namespace BBDown.Core.Fetcher
                         m.GetProperty("cover").ToString(),
                         desc,
                         ownerName,
-                        ownerMid);
+                        ownerMid,
+                        isSingleP);
                         if (!pagesInfo.Contains(p)) pagesInfo.Add(p);
                         else index--;
                     }

--- a/BBDown.Core/Fetcher/SpaceVideoFetcher.cs
+++ b/BBDown.Core/Fetcher/SpaceVideoFetcher.cs
@@ -28,10 +28,10 @@ namespace BBDown.Core.Fetcher
             int totalCount = infoJson.RootElement.GetProperty("data").GetProperty("page").GetProperty("count").GetInt32();
             int totalPage = (int)Math.Ceiling((double)totalCount / pageSize);
 
-            while (pageNumber < totalPage)
+            while (pageNumber <= totalPage)
             {
-                pageNumber++;
                 aidList.AddRange(await GetVideosByPageAsync(pageNumber, pageSize, id));
+                pageNumber++;
             }
 
             List<Page> pagesInfo = new List<Page>();
@@ -39,6 +39,7 @@ namespace BBDown.Core.Fetcher
             foreach (var aid in aidList)
             {
                 var tmpInfo = await new NormalInfoFetcher().FetchAsync(aid);
+                Thread.Sleep(100);
                 foreach (var item in tmpInfo.PagesInfo)
                 {
                     Page p = new Page(index++, item);

--- a/BBDown.Core/Fetcher/SpaceVideoFetcher.cs
+++ b/BBDown.Core/Fetcher/SpaceVideoFetcher.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using static BBDown.Core.Entity.Entity;
 using static BBDown.Core.Util.HTTPUtil;
 using static BBDown.Core.Logger;
 
@@ -17,46 +18,60 @@ namespace BBDown.Core.Fetcher
             id = id.Substring(4);
             string userInfoApi = $"https://api.bilibili.com/x/space/acc/info?mid={id}&jsonp=jsonp";
             string userName = GetValidFileName(JsonDocument.Parse(await GetWebSourceAsync(userInfoApi)).RootElement.GetProperty("data").GetProperty("name").ToString(), ".", true);
-            List<string> urls = new List<string>();
+            List<string> aidList = new List<string>();
             int pageSize = 50;
             int pageNumber = 1;
             string api = $"https://api.bilibili.com/x/space/arc/search?mid={id}&ps={pageSize}&tid=0&pn={pageNumber}&keyword=&order=pubdate&jsonp=jsonp";
             string json = await GetWebSourceAsync(api);
             var infoJson = JsonDocument.Parse(json);
             var pages = infoJson.RootElement.GetProperty("data").GetProperty("list").GetProperty("vlist").EnumerateArray();
-            foreach (var page in pages)
-            {
-                urls.Add($"https://www.bilibili.com/video/av{page.GetProperty("aid")}");
-            }
             int totalCount = infoJson.RootElement.GetProperty("data").GetProperty("page").GetProperty("count").GetInt32();
             int totalPage = (int)Math.Ceiling((double)totalCount / pageSize);
+
             while (pageNumber < totalPage)
             {
                 pageNumber++;
-                urls.AddRange(await GetVideosByPageAsync(pageNumber, pageSize,  id));
+                aidList.AddRange(await GetVideosByPageAsync(pageNumber, pageSize, id));
             }
-            File.WriteAllText($"{userName}的投稿视频.txt", string.Join('\n', urls));
-            Log("目前下载器不支持下载用户的全部投稿视频，不过程序已经获取到了该用户的全部投稿视频地址，你可以自行使用批处理脚本等手段调用本程序进行批量下载。如在Windows系统你可以使用如下代码：");
-            Console.WriteLine();
-            Console.WriteLine(@"@echo Off
-For /F %%a in (urls.txt) Do (BBDown.exe ""%%a"")
-pause");
-            Console.WriteLine();
-            throw new Exception("暂不支持该功能");
+
+            List<Page> pagesInfo = new List<Page>();
+            int index = 1;
+            foreach (var aid in aidList)
+            {
+                var tmpInfo = await new NormalInfoFetcher().FetchAsync(aid);
+                foreach (var item in tmpInfo.PagesInfo)
+                {
+                    Page p = new Page(index++, item);
+                    if (!pagesInfo.Contains(p)) pagesInfo.Add(p);
+                }
+            }
+
+            var info = new VInfo();
+            // 空间标题，取作者名称
+            info.Title = userName;
+            // todo, PubTime 理论应该跟着视频走
+            info.PubTime = "";  
+            info.PagesInfo = pagesInfo;
+            info.IsBangumi = false;
+            info.IsFavList = true;
+
+            return info;
+
+
         }
 
         async Task<List<string>> GetVideosByPageAsync(int pageNumber, int pageSize, string mid)
         {
-            List<string> urls = new List<string>();
+            List<string> aidList = new List<string>();
             string api = $"https://api.bilibili.com/x/space/arc/search?mid={mid}&ps={pageSize}&tid=0&pn={pageNumber}&keyword=&order=pubdate&jsonp=jsonp";
             string json = await GetWebSourceAsync(api);
             var infoJson = JsonDocument.Parse(json);
             var pages = infoJson.RootElement.GetProperty("data").GetProperty("list").GetProperty("vlist").EnumerateArray();
             foreach (var page in pages)
             {
-                urls.Add($"https://www.bilibili.com/video/av{page.GetProperty("aid")}");
+                aidList.Add(page.GetProperty("aid").ToString());
             }
-            return urls;
+            return aidList;
         }
 
         private static string GetValidFileName(string input, string re = ".", bool filterSlash = false)

--- a/BBDown/Program.cs
+++ b/BBDown/Program.cs
@@ -707,12 +707,13 @@ namespace BBDown
                     pagesInfo = pagesInfo.Where(p => selectedPages.Contains(p.index.ToString())).ToList();
 
                 // 根据p数选择存储路径
-                savePathFormat = string.IsNullOrEmpty(myOption.FilePattern) ? SinglePageDefaultSavePath : myOption.FilePattern;
+                var singlePageSavePath = string.IsNullOrEmpty(myOption.FilePattern) ? SinglePageDefaultSavePath : myOption.FilePattern;
+                var multiPageSavePath = string.IsNullOrEmpty(myOption.MultiFilePattern) ? MultiPageDefaultSavePath : myOption.MultiFilePattern;
                 // 1. 多P; 2. 只有1P，但是是番剧，尚未完结时 按照多P处理
-                if (pagesCount > 1 || (bangumi && !vInfo.IsBangumiEnd))
-                {
-                    savePathFormat = string.IsNullOrEmpty(myOption.MultiFilePattern) ? MultiPageDefaultSavePath : myOption.MultiFilePattern;
-                }
+                // if (pagesCount > 1 || (bangumi && !vInfo.IsBangumiEnd))
+                // {
+                //     savePathFormat = string.IsNullOrEmpty(myOption.MultiFilePattern) ? MultiPageDefaultSavePath : myOption.MultiFilePattern;
+                // }
 
                 foreach (Page p in pagesInfo)
                 {
@@ -889,6 +890,8 @@ namespace BBDown
                                 audioTracks[aIndex].baseUrl = pcdnReg.Replace(audioTracks[aIndex].baseUrl, $"://{BACKUP_HOST}/");
                             }
 
+                            // 判断p的处理方式
+                            savePathFormat = p.isSingleP ? singlePageSavePath : multiPageSavePath;
                             LogDebug("Format Before: " + savePathFormat);
                             savePath = FormatSavePath(savePathFormat, title, videoTracks.ElementAtOrDefault(vIndex), audioTracks.ElementAtOrDefault(aIndex), p, pagesCount);
                             LogDebug("Format After: " + savePath);

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Options:
                                                  <audioBandwidth>: 音频码率
                                                  <ownerName>: 上传者名称
                                                  <ownerMid>: 上传者mid
+                                                 <mainTitle>: 视频主标题/合集标题/收藏夹标题（根据场景区分）
 
                                                  默认为: <videoTitle>
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Options:
                                                  <audioBandwidth>: 音频码率
                                                  <ownerName>: 上传者名称
                                                  <ownerMid>: 上传者mid
-                                                 <mainTitle>: 视频主标题/合集标题/收藏夹标题（根据场景区分）
+                                                 <mainTitle>: 合集标题/收藏夹标题（下载合集标题和收藏夹时使用）
 
                                                  默认为: <videoTitle>
 


### PR DESCRIPTION
# 目前的问题
目前有一个问题是下载收藏夹列表时，命名参数`videoTitle`和下载普通文件是不一致的，比如下载收藏夹`https://space.bilibili.com/81824112/favlist?fid=1356346646`解析时实际上赋值给VInfo对象的title是收藏夹的名称，而非视频本身的title

https://github.com/nilaoda/BBDown/blob/master/BBDown.Core/Fetcher/FavListFetcher.cs#L45
```c#
int totalPage = (int)Math.Ceiling((double)totalCount / pageSize);
var title = data.GetProperty("info").GetProperty("title").ToString();  // 这里获取的是收藏夹列表的title
var intro = data.GetProperty("info").GetProperty("intro").GetString();
.......
.......
var info = new VInfo();  
info.Title = title.Trim();  
```
title直接赋值给vinfo的title，然后传递给`savePathFormat`,最终替换`videoTitle`，进入命名流程，此处`videoTitle`是收藏夹的名称而不是视频的名称

对于同一个命名模板配置，相同的视频下载，直接通过某个视频链接下载视频A和通过收藏夹下载视频A，最后的名称就会不一致。

比如对于视频A，走模板
```
--file-pattern r://bbdown-dl/<ownerName>/[<videoTitle>][<pageTitle>][<aid>]
```
结果
```
r://bbdown-dl/upperName/[收藏夹名称][视频标题-视频分p标题][123456].mp4    // 下载收藏夹
r://bbdown-dl/upperName/[视频标题][视频分p标题][123456].mp4   // 直接下载视频链接
```

这里现有的逻辑是内部把videoTitle和pageTitle粘在一起了

# 预期
预期是<videoTitle><pageTitle><aid>这些参数对于一个普通投稿视频（不包含番剧）是相对不变的。

对于一个普通的b站视频[https://www.bilibili.com/video/BV1BT4y1a7jQ](https://www.bilibili.com/video/BV1BT4y1a7jQ)，`NormalInfoFetcher`的解析是正确的，这个视频BV1BT4y1a7jQ，其实更像一个视频组，只不过只有1个分P，\<videoTitle\>是视频组标题，\<pageTitle\>是分p标题，只有1个分P的时候\<pageTitle\>网页上是不展示的

这是一个双分P视频[https://www.bilibili.com/video/BV1Fv4y1w7UY?p=1](https://www.bilibili.com/video/BV1Fv4y1w7UY?p=1)其实更好的说明这个问题。在这里分P\<pageTitle\>在网页上是展示的，体现在播放列表里

b站每一个普通投稿稿件应该是一个视频组，\<videoTitle\>应该是视频组，也就稿件的名称，\<pageTitle\>是分P的名称，\<videoTitle\>对于**同一份稿件**应该是不变的，类似的问题也会出现在合辑里面，包括后续在完善直接下载空间视频的功能时，也会遇到这个问题，所以提前提出来讨论。

# 预期改造方式

但是对于下载而言，基本单位是每个分P，而不是一个稿件。考虑到目前每个fetcher返回的都是VInfo对象，并且存在FavListFetcher里面调用NormalInfoFetcher的情况。要做到命名一致性最好把videoTitle，desc等挂在每个page对象上，最后通过pagesInfo传到命名函数

原逻辑
```c#
var info = new VInfo();
info.Title = title.Trim();
info.Desc = desc.Trim();
info.Pic = pic;
info.PubTime = pubTime;
info.PagesInfo = pagesInfo;
info.IsBangumi = bangumi;
```

改后逻辑
```c#
foreach (var page in pages)
{
    Page p = new Page(page.GetProperty("page").GetInt32(),
        id,
        page.GetProperty("cid").ToString(),
        "", //epid
        page.GetProperty("part").ToString().Trim(),
        page.GetProperty("duration").GetInt32(),
        page.GetProperty("dimension").GetProperty("width").ToString() + "x" + page.GetProperty("dimension").GetProperty("height").ToString(),
        "",
        "",
        ownerName,
        ownerMid,
        videoTitle, // 伪代码：直接让相关信息跟着分p走
        pageTitle,
        desc,
        );
    pagesInfo.Add(p);
}
......
......
var info = new VInfo();
info,title = title // 保留一个主标题，可以是收藏夹名称，合集名称或者视频组名称
info.PagesInfo = pagesInfo; // 基本所有信息都跟着pageInfo走
info.IsBangumi = bangumi;
```

1、单p，多p理想情况下应该是：

```
稿件1 P1
稿件2 P1
稿件2 P2
稿件3 P1
稿件3 P2
```

单独下载一个稿件是单P走`--file-pattern`,多P走`--multi-file-pattern`，感觉这个设计是合理的，因为涉及到单P和稿件名称不一致的命名的问题。

但是目前走合集或者收藏夹的，`p.index`还是混在一个大列表里，导致都走的是`--multi-file-pattern`。本pr在处理合辑、收藏夹、视频空间的过程中针对不同的稿件单P走`--file-pattern`,多P走`--multi-file-pattern`。同时抹平了之前命名处理的差异性，暴露\<videoTitle\>和\<pageTitle\>原始值，方便自由配置。

唯一没有改完的是p.index相关的逻辑，这块后续在说吧。。。

2、番剧和课程实际逻辑没有变动，因为透传的值变了，做了调整。

3、在完成上述改造的情况下，增加space空间下载支持

