### PR TITLE
feat: 优化多线程下载

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -360,3 +360,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# ignore local build
+artifact-x64


### PR DESCRIPTION
1、增加了一个gitignore内容，方便本地调试

2、多线程部分增加一个分组，当下载大文件时，比如3,4个G，allClips有300多个分片，容易出现较大的http连接数，很容易失败。在这个基础上增加一个50个为一组，可以缓解这个问题。对于一般场景，应该也不会有变慢的影响，b站视频一般普遍也小于500M