### PR TITLE
移除ffmpeg '-f mp4' 参数, 将大部分全角替换为半角

### DIFF
--- a/BBDown.Core/DanmakuUtil.cs
+++ b/BBDown.Core/DanmakuUtil.cs
@@ -93,7 +93,7 @@ namespace BBDown.Core
             sb.AppendLine($"Style: BBDOWN_Style, 黑体, {FONT_SIZE}, &H00FFFFFF, &H00FFFFFF, &H00000000, &H00000000, 0, 0, 0, 0, 100, 100, 0.00, 0.00, 1, 2, 0, 7, 0, 0, 0, 0");
             sb.AppendLine("[Events]");
             sb.AppendLine("Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text");
-            
+
             PositionController controller = new();   // 弹幕位置控制器
             Array.Sort(danmakus, comparer);
             foreach (DanmakuItem danmaku in danmakus)
@@ -120,7 +120,7 @@ namespace BBDown.Core
         protected class PositionController
         {
             readonly int maxLine = MONITOR_HEIGHT * PROTECT_LENGTH / FONT_SIZE / 100;    //总行数
-                                                                                        // 三个位置的弹幕队列，记录弹幕结束时间
+                                                                                        // 三个位置的弹幕队列, 记录弹幕结束时间
 
             readonly List<double> moveQueue = new();
             readonly List<double> topQueue = new();
@@ -157,7 +157,7 @@ namespace BBDown.Core
                 for (int i = 0; i < maxLine; i++)
                 {
                     if (time >= vs[i])
-                    {   // 此条弹幕已结束，更新该位置信息
+                    {   // 此条弹幕已结束, 更新该位置信息
                         vs[i] = time + displayTime;
                         return i * FONT_SIZE;
                     }

--- a/BBDown.Core/Fetcher/BangumiInfoFetcher.cs
+++ b/BBDown.Core/Fetcher/BangumiInfoFetcher.cs
@@ -23,7 +23,7 @@ namespace BBDown.Core.Fetcher
             List<Page> pagesInfo = new();
             int i = 1;
 
-            //episodes为空; 或者未包含对应epid，番外/花絮什么的
+            //episodes为空; 或者未包含对应epid, 番外/花絮什么的
             if (pages.Count == 0 || !result.GetProperty("episodes").ToString().Contains($"/ep{id}"))
             {
                 if (result.TryGetProperty("section", out JsonElement sections))

--- a/BBDown.Core/Fetcher/NormalInfoFetcher.cs
+++ b/BBDown.Core/Fetcher/NormalInfoFetcher.cs
@@ -49,7 +49,7 @@ namespace BBDown.Core.Fetcher
                 {
                     bangumi = true;
                     string epId = EpIdRegex().Match(data.GetProperty("redirect_url").ToString()).Groups[1].Value;
-                    //番剧内容通常不会有分P，如果有分P则不需要epId参数
+                    //番剧内容通常不会有分P, 如果有分P则不需要epId参数
                     if (pages.Count == 1)
                     {
                         pagesInfo.ForEach(p => p.epid = epId);

--- a/BBDown.Core/Fetcher/SpaceVideoFetcher.cs
+++ b/BBDown.Core/Fetcher/SpaceVideoFetcher.cs
@@ -31,7 +31,7 @@ namespace BBDown.Core.Fetcher
                 urls.AddRange(await GetVideosByPageAsync(pageNumber, pageSize,  id));
             }
             File.WriteAllText($"{userName}的投稿视频.txt", string.Join('\n', urls));
-            Log("目前下载器不支持下载用户的全部投稿视频，不过程序已经获取到了该用户的全部投稿视频地址，你可以自行使用批处理脚本等手段调用本程序进行批量下载。如在Windows系统你可以使用如下代码：");
+            Log("目前下载器不支持下载用户的全部投稿视频, 不过程序已经获取到了该用户的全部投稿视频地址, 你可以自行使用批处理脚本等手段调用本程序进行批量下载。如在Windows系统你可以使用如下代码: ");
             Console.WriteLine();
             Console.WriteLine(@"@echo Off
 For /F %%a in (urls.txt) Do (BBDown.exe ""%%a"")

--- a/BBDown.Core/Parser.cs
+++ b/BBDown.Core/Parser.cs
@@ -51,7 +51,7 @@ namespace BBDown.Core
             //以下情况从网页源代码尝试解析
             if (webJson.Contains("\"大会员专享限制\""))
             {
-                Log("此视频需要大会员，您大概率需要登录一个有大会员的账号才可以下载，尝试从网页源码解析");
+                Log("此视频需要大会员, 您大概率需要登录一个有大会员的账号才可以下载, 尝试从网页源码解析");
                 string webUrl = "https://www.bilibili.com/bangumi/play/ep" + epId;
                 string webSource = await GetWebSourceAsync(webUrl);
                 webJson = PlayerJsonRegex().Match(webSource).Groups[1].Value;
@@ -216,7 +216,7 @@ namespace BBDown.Core
                     }
                 }
 
-                //此处处理免二压视频，需要单独再请求一次
+                //此处处理免二压视频, 需要单独再请求一次
                 if (!reParse && !appApi)
                 {
                     reParse = true;
@@ -295,7 +295,7 @@ namespace BBDown.Core
                 }
                 else
                 {
-                    //如果获取数据失败，尝试从根路径获取数据
+                    //如果获取数据失败, 尝试从根路径获取数据
                     string nodeinfo = respJson.RootElement.ToString();
                     var nodeJson = JsonDocument.Parse(nodeinfo).RootElement;
                     quality = nodeJson.GetProperty("quality").ToString();

--- a/BBDown.Core/Util/HTTPUtil.cs
+++ b/BBDown.Core/Util/HTTPUtil.cs
@@ -27,7 +27,7 @@ namespace BBDown.Core.Util
             webRequest.Headers.CacheControl = CacheControlHeaderValue.Parse("no-cache");
             webRequest.Headers.Connection.Clear();
 
-            LogDebug("获取网页内容：Url: {0}, Headers: {1}", url, webRequest.Headers);
+            LogDebug("获取网页内容: Url: {0}, Headers: {1}", url, webRequest.Headers);
             var webResponse = (await AppHttpClient.SendAsync(webRequest, HttpCompletionOption.ResponseHeadersRead)).EnsureSuccessStatusCode();
 
             string htmlCode = await webResponse.Content.ReadAsStringAsync();

--- a/BBDown.Core/Util/SubUtil.cs
+++ b/BBDown.Core/Util/SubUtil.cs
@@ -164,7 +164,7 @@ namespace BBDown.Core.Util
                 "uk"                => ("ukr", "Українська"),
                 "ur"                => ("urd", "Urdu"),
                 "vi"                => ("vie", "Tiếng Việt"),
-                //太多了，我蚌埠住了，后面懒得查
+                //太多了, 我蚌埠住了, 后面懒得查
                 //"ie"                => ("", ""),
                 //"oc"                => ("",   ""),
                 //"or"                => ("",   ""),
@@ -257,7 +257,7 @@ namespace BBDown.Core.Util
                     };
                     subtitles.Add(subtitle);
                 }
-                //无字幕片源 但是字幕没上导致的空列表，尝试从国际接口获取
+                //无字幕片源 但是字幕没上导致的空列表, 尝试从国际接口获取
                 //if (subtitles.Count == 0 && !string.IsNullOrEmpty(epId))
                 //{
                 //    return await GetSubtitlesAsync(aid, cid, epId, true);

--- a/BBDown/BBDownConfigParser.cs
+++ b/BBDown/BBDownConfigParser.cs
@@ -59,7 +59,7 @@ namespace BBDown
             }
             catch (Exception)
             {
-                LogError("配置文件读取异常，忽略");
+                LogError("配置文件读取异常, 忽略");
             }
         }
     }

--- a/BBDown/BBDownMuxer.cs
+++ b/BBDown/BBDownMuxer.cs
@@ -89,7 +89,7 @@ namespace BBDown
 
             //----分析完毕
             var arguments = inputArg.ToString() + (metaArg.ToString() == "" ? "" : " -itags tool=" + metaArg.ToString()) + $" -new \"{outPath}\"";
-            LogDebug("mp4box命令：{0}", arguments);
+            LogDebug("mp4box命令: {0}", arguments);
             return RunExe(MP4BOX, arguments, MP4BOX != "mp4box");
         }
 
@@ -159,7 +159,7 @@ namespace BBDown
                  (subs != null ? " -c:s mov_text " : "") +
                  "-movflags faststart -strict unofficial -strict -2 " +
                  $"\"{outPath}\"";
-            LogDebug("ffmpeg命令：{0}", arguments);
+            LogDebug("ffmpeg命令: {0}", arguments);
             return RunExe(FFMPEG, arguments, FFMPEG != "ffmpeg");
         }
 
@@ -175,7 +175,7 @@ namespace BBDown
                 {
                     var tmpFile = Path.Combine(Path.GetDirectoryName(file)!, Path.GetFileNameWithoutExtension(file) + ".ts");
                     var arguments = $"-loglevel warning -y -i \"{file}\" -map 0 -c copy -f mpegts -bsf:v h264_mp4toannexb \"{tmpFile}\"";
-                    LogDebug("ffmpeg命令：{0}", arguments);
+                    LogDebug("ffmpeg命令: {0}", arguments);
                     RunExe("ffmpeg", arguments);
                     File.Delete(file);
                 }

--- a/BBDown/BBDownUtil.cs
+++ b/BBDown/BBDownUtil.cs
@@ -32,7 +32,7 @@ namespace BBDown
                 string latestVer = redirctUrl.Replace("https://github.com/nilaoda/BBDown/releases/tag/", "");
                 if (nowVer != latestVer && !latestVer.StartsWith("https"))
                 {
-                    Console.Title = $"发现新版本：{latestVer}";
+                    Console.Title = $"发现新版本: {latestVer}";
                 }
             }
             catch (Exception)
@@ -209,7 +209,7 @@ namespace BBDown
         }
 
         /// <summary>
-        /// 通过avid检测是否为版权内容，如果是的话返回ep:xx格式
+        /// 通过avid检测是否为版权内容, 如果是的话返回ep:xx格式
         /// </summary>
         /// <param name="avid"></param>
         /// <returns></returns>
@@ -372,7 +372,7 @@ namespace BBDown
                 return;
             }
             long fileSize = await GetFileSizeAsync(url);
-            LogDebug("文件大小：{0} bytes", fileSize);
+            LogDebug("文件大小: {0} bytes", fileSize);
             //已下载过, 跳过下载
             if (File.Exists(path) && new FileInfo(path).Length == fileSize)
             {
@@ -381,7 +381,7 @@ namespace BBDown
             }
             List<Clip> allClips = GetAllClips(url, fileSize);
             int total = allClips.Count;
-            LogDebug("分段数量：{0}", total);
+            LogDebug("分段数量: {0}", total);
             ConcurrentDictionary<int, long> clipProgress = new();
             foreach (var i in allClips) clipProgress[i.index] = 0;
 
@@ -402,7 +402,7 @@ namespace BBDown
                 }
                 catch (NotSupportedException)
                 {
-                    if (++retry == 3) throw new Exception($"服务器可能并不支持多线程下载，请使用 --multi-thread false 关闭多线程");
+                    if (++retry == 3) throw new Exception($"服务器可能并不支持多线程下载, 请使用 --multi-thread false 关闭多线程");
                     goto reDown;
                 }
                 catch (Exception)
@@ -448,7 +448,7 @@ namespace BBDown
         }
 
         /// <summary>
-        /// 输入一堆已存在的文件，合并到新文件
+        /// 输入一堆已存在的文件, 合并到新文件
         /// </summary>
         /// <param name="files"></param>
         /// <param name="outputFilePath"></param>
@@ -564,7 +564,7 @@ namespace BBDown
 
 
         /// <summary>
-        /// 获取url字符串参数，返回参数值字符串
+        /// 获取url字符串参数, 返回参数值字符串
         /// </summary>
         /// <param name="name">参数名称</param>
         /// <param name="url">url字符串</param>
@@ -750,7 +750,7 @@ namespace BBDown
         }
 
         /// <summary>
-        /// 生成metadata文件，用于ffmpeg混流章节信息
+        /// 生成metadata文件, 用于ffmpeg混流章节信息
         /// </summary>
         /// <param name="points"></param>
         /// <returns></returns>
@@ -772,7 +772,7 @@ namespace BBDown
         }
 
         /// <summary>
-        /// 生成metadata文件，用于mp4box混流章节信息
+        /// 生成metadata文件, 用于mp4box混流章节信息
         /// </summary>
         /// <param name="points"></param>
         /// <returns></returns>

--- a/BBDown/MyOption.cs
+++ b/BBDown/MyOption.cs
@@ -48,7 +48,7 @@ namespace BBDown
         public string EpHost { get; set; } = "api.bilibili.com";
         public string Area { get; set; } = "";
         public string? ConfigFile { get; set; }
-        //以下仅为兼容旧版本命令行，不建议使用
+        //以下仅为兼容旧版本命令行, 不建议使用
         public string Aria2cProxy { get; set; } = "";
         public bool OnlyHevc { get; set; }
         public bool OnlyAvc { get; set; }

--- a/BBDown/Program.cs
+++ b/BBDown/Program.cs
@@ -69,7 +69,7 @@ namespace BBDown
             var ver = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version!;
             Console.Write($"BBDown version {ver.Major}.{ver.Minor}.{ver.Build}, Bilibili Downloader.\r\n");
             Console.ResetColor();
-            Console.Write("欢迎到讨论区交流：\r\n" +
+            Console.Write("欢迎到讨论区交流: \r\n" +
                 "https://github.com/nilaoda/BBDown/discussions\r\n");
             Console.WriteLine();
 
@@ -110,7 +110,7 @@ namespace BBDown
                 //兼容旧版本命令行参数并给出警告
                 if (myOption.AddDfnSubfix)
                 {
-                    LogWarn("--add-dfn-subfix 已被弃用，建议使用 --file-pattern/-F 或 --multi-file-pattern/-M 来自定义输出文件名格式");
+                    LogWarn("--add-dfn-subfix 已被弃用, 建议使用 --file-pattern/-F 或 --multi-file-pattern/-M 来自定义输出文件名格式");
                     if (string.IsNullOrEmpty(myOption.FilePattern) && string.IsNullOrEmpty(myOption.MultiFilePattern))
                     {
                         SinglePageDefaultSavePath += "[<dfn>]";
@@ -120,27 +120,27 @@ namespace BBDown
                 }
                 if (myOption.Aria2cProxy != "")
                 {
-                    LogWarn("--aria2c-proxy 已被弃用，请使用 --aria2c-args 来设置aria2c代理，本次执行已添加该代理");
+                    LogWarn("--aria2c-proxy 已被弃用, 请使用 --aria2c-args 来设置aria2c代理, 本次执行已添加该代理");
                     myOption.Aria2cArgs += $" --all-proxy=\"{myOption.Aria2cProxy}\"";
                 }
                 if (myOption.OnlyHevc)
                 {
-                    LogWarn("--only-hevc/-hevc 已被弃用，请使用 --encoding-priority 来设置编码优先级，本次执行已将hevc设置为最高优先级");
+                    LogWarn("--only-hevc/-hevc 已被弃用, 请使用 --encoding-priority 来设置编码优先级, 本次执行已将hevc设置为最高优先级");
                     myOption.EncodingPriority = "hevc";
                 }
                 if (myOption.OnlyAvc)
                 {
-                    LogWarn("--only-avc/-avc 已被弃用，请使用 --encoding-priority 来设置编码优先级，本次执行已将avc设置为最高优先级");
+                    LogWarn("--only-avc/-avc 已被弃用, 请使用 --encoding-priority 来设置编码优先级, 本次执行已将avc设置为最高优先级");
                     myOption.EncodingPriority = "avc";
                 }
                 if (myOption.OnlyAv1)
                 {
-                    LogWarn("--only-av1/-av1 已被弃用，请使用 --encoding-priority 来设置编码优先级，本次执行已将av1设置为最高优先级");
+                    LogWarn("--only-av1/-av1 已被弃用, 请使用 --encoding-priority 来设置编码优先级, 本次执行已将av1设置为最高优先级");
                     myOption.EncodingPriority = "av1";
                 }
                 if (myOption.NoPaddingPageNum)
                 {
-                    LogWarn("--no-padding-page-num 已被弃用，建议使用 --file-pattern/-F 或 --multi-file-pattern/-M 来自定义输出文件名格式");
+                    LogWarn("--no-padding-page-num 已被弃用, 建议使用 --file-pattern/-F 或 --multi-file-pattern/-M 来自定义输出文件名格式");
                     if (string.IsNullOrEmpty(myOption.FilePattern) && string.IsNullOrEmpty(myOption.MultiFilePattern))
                     {
                         MultiPageDefaultSavePath = MultiPageDefaultSavePath.Replace("<pageNumberWithZero>", "<pageNumber>");
@@ -217,7 +217,7 @@ namespace BBDown
                     }
                     //设置工作目录
                     Environment.CurrentDirectory = dir;
-                    LogDebug("切换工作目录至：{0}", dir);
+                    LogDebug("切换工作目录至: {0}", dir);
                 }
 
                 if (!string.IsNullOrEmpty(myOption.FFmpegPath) && File.Exists(myOption.FFmpegPath))
@@ -290,24 +290,24 @@ namespace BBDown
                 }
 
                 LogDebug("AppDirectory: {0}", APP_DIR);
-                LogDebug("运行参数：{0}", JsonSerializer.Serialize(myOption, MyOptionJsonContext.Default.MyOption));
+                LogDebug("运行参数: {0}", JsonSerializer.Serialize(myOption, MyOptionJsonContext.Default.MyOption));
                 if (string.IsNullOrEmpty(Config.COOKIE) && File.Exists(Path.Combine(APP_DIR, "BBDown.data")))
                 {
                     Log("加载本地cookie...");
-                    LogDebug("文件路径：{0}", Path.Combine(APP_DIR, "BBDown.data"));
+                    LogDebug("文件路径: {0}", Path.Combine(APP_DIR, "BBDown.data"));
                     Config.COOKIE = File.ReadAllText(Path.Combine(APP_DIR, "BBDown.data"));
                 }
                 if (string.IsNullOrEmpty(Config.TOKEN) && File.Exists(Path.Combine(APP_DIR, "BBDownTV.data")) && tvApi)
                 {
                     Log("加载本地token...");
-                    LogDebug("文件路径：{0}", Path.Combine(APP_DIR, "BBDownTV.data"));
+                    LogDebug("文件路径: {0}", Path.Combine(APP_DIR, "BBDownTV.data"));
                     Config.TOKEN = File.ReadAllText(Path.Combine(APP_DIR, "BBDownTV.data"));
                     Config.TOKEN = Config.TOKEN.Replace("access_token=", "");
                 }
                 if (string.IsNullOrEmpty(Config.TOKEN) && File.Exists(Path.Combine(APP_DIR, "BBDownApp.data")) && appApi)
                 {
                     Log("加载本地token...");
-                    LogDebug("文件路径：{0}", Path.Combine(APP_DIR, "BBDownApp.data"));
+                    LogDebug("文件路径: {0}", Path.Combine(APP_DIR, "BBDownApp.data"));
                     Config.TOKEN = File.ReadAllText(Path.Combine(APP_DIR, "BBDownApp.data"));
                     Config.TOKEN = Config.TOKEN.Replace("access_token=", "");
                 }
@@ -325,7 +325,7 @@ namespace BBDown
                 Log("获取aid...");
                 aidOri = await GetAvIdAsync(input);
                 Log("获取aid结束: " + aidOri);
-                //-p的优先级大于URL中的自带p参数，所以先清空selectedPages
+                //-p的优先级大于URL中的自带p参数, 所以先清空selectedPages
                 if (!string.IsNullOrEmpty(selectPage) && selectPage != "ALL")
                 {
                     selectedPages = new List<string>();
@@ -420,14 +420,14 @@ namespace BBDown
                     catch { LogError("解析分P参数时失败了~"); selectedPages = null; };
                 }
 
-                //如果用户没有选择分P，根据epid来确定某一集
+                //如果用户没有选择分P, 根据epid来确定某一集
                 if (selectedPages == null && selectPage != "ALL" && !string.IsNullOrEmpty(vInfo.Index))
                 {
                     selectedPages = new List<string> { vInfo.Index };
-                    Log("程序已自动选择你输入的集数，如果要下载其他集数请自行指定分P(如可使用-p ALL代表全部)");
+                    Log("程序已自动选择你输入的集数, 如果要下载其他集数请自行指定分P(如可使用-p ALL代表全部)");
                 }
 
-                Log($"共计 {pagesInfo.Count} 个分P, 已选择：" + (selectedPages == null ? "ALL" : string.Join(",", selectedPages)));
+                Log($"共计 {pagesInfo.Count} 个分P, 已选择: " + (selectedPages == null ? "ALL" : string.Join(",", selectedPages)));
                 var pagesCount = pagesInfo.Count;
 
                 //过滤不需要的分P
@@ -436,7 +436,7 @@ namespace BBDown
 
                 // 根据p数选择存储路径
                 savePathFormat = string.IsNullOrEmpty(myOption.FilePattern) ? SinglePageDefaultSavePath : myOption.FilePattern;
-                // 1. 多P; 2. 只有1P，但是是番剧，尚未完结时 按照多P处理
+                // 1. 多P; 2. 只有1P, 但是是番剧, 尚未完结时 按照多P处理
                 if (pagesCount > 1 || (bangumi && !vInfo.IsBangumiEnd))
                 {
                     savePathFormat = string.IsNullOrEmpty(myOption.MultiFilePattern) ? MultiPageDefaultSavePath : myOption.MultiFilePattern;
@@ -489,7 +489,7 @@ namespace BBDown
                                 var cover = pic == "" ? p.cover : pic;
                                 if (cover != null)
                                 {
-                                    LogDebug("下载：{0}", cover);
+                                    LogDebug("下载: {0}", cover);
                                     await using var response = await HTTPUtil.AppHttpClient.GetStreamAsync(cover);
                                     await using var fs = new FileStream(coverPath, FileMode.Create);
                                     await response.CopyToAsync(fs);
@@ -507,7 +507,7 @@ namespace BBDown
                                         continue;
                                     }
                                     Log($"下载字幕 {s.lan} => {SubUtil.GetSubtitleCode(s.lan).Item2}...");
-                                    LogDebug("下载：{0}", s.url);
+                                    LogDebug("下载: {0}", s.url);
                                     await SubUtil.SaveSubtitleAsync(s.url, s.path);
                                     if (subOnly && File.Exists(s.path) && File.ReadAllText(s.path) != "")
                                     {
@@ -538,7 +538,7 @@ namespace BBDown
 
                         var savePath = "";
 
-                        //此处代码简直灾难，后续优化吧
+                        //此处代码简直灾难, 后续优化吧
                         if ((videoTracks.Count != 0 || audioTracks.Count != 0) && clips.Count == 0)   //dash
                         {
                             if (webJsonStr.Contains("\"video\":[") && videoTracks.Count == 0)
@@ -617,13 +617,13 @@ namespace BBDown
                             var pcdnReg = PcdnRegex();
                             if (videoTracks.Count > 0 && pcdnReg.IsMatch(videoTracks[vIndex].baseUrl))
                             {
-                                LogWarn($"检测到视频流为PCDN，尝试强制替换为{BACKUP_HOST}……");
+                                LogWarn($"检测到视频流为PCDN, 尝试强制替换为{BACKUP_HOST}……");
                                 videoTracks[vIndex].baseUrl = pcdnReg.Replace(videoTracks[vIndex].baseUrl, $"://{BACKUP_HOST}/");
                             }
 
                             if (audioTracks.Count > 0 && pcdnReg.IsMatch(audioTracks[aIndex].baseUrl))
                             {
-                                LogWarn($"检测到音频流为PCDN，尝试强制替换为{BACKUP_HOST}……");
+                                LogWarn($"检测到音频流为PCDN, 尝试强制替换为{BACKUP_HOST}……");
                                 audioTracks[aIndex].baseUrl = pcdnReg.Replace(audioTracks[aIndex].baseUrl, $"://{BACKUP_HOST}/");
                             }
 
@@ -665,7 +665,7 @@ namespace BBDown
                                     continue;
                                 }
 
-                                //杜比视界，若ffmpeg版本小于5.0，使用mp4box封装
+                                //杜比视界, 若ffmpeg版本小于5.0, 使用mp4box封装
                                 if (videoTracks[vIndex].dfn == Config.qualitys["126"] && !useMp4box && !CheckFFmpegDOVI())
                                 {
                                     LogWarn($"检测到杜比视界清晰度且您的ffmpeg版本小于5.0,将使用mp4box混流...");
@@ -860,11 +860,11 @@ namespace BBDown
                         {
                             if (webJsonStr.Contains("平台不可观看"))
                             {
-                                throw new Exception("当前(WEB)平台不可观看，请尝试使用TV API解析。");
+                                throw new Exception("当前(WEB)平台不可观看, 请尝试使用TV API解析。");
                             }
                             else if (webJsonStr.Contains("地区不可观看") || webJsonStr.Contains("地区不支持"))
                             {
-                                throw new Exception("当前地区不可观看，尝试设置系统代理后解析。");
+                                throw new Exception("当前地区不可观看, 尝试设置系统代理后解析。");
                             }
                             else if (webJsonStr.Contains("购买后才能观看"))
                             {
@@ -903,7 +903,7 @@ namespace BBDown
 
         private static List<Video> SortTracks(List<Video> videoTracks, Dictionary<string, int> dfnPriority, Dictionary<string, byte> encodingPriority, bool bandwithAscending)
         {
-            //用户同时输入了自定义分辨率优先级和自定义编码优先级，则根据输入顺序依次进行排序
+            //用户同时输入了自定义分辨率优先级和自定义编码优先级, 则根据输入顺序依次进行排序
             return dfnPriority.Count > 0 && encodingPriority.Count > 0 && Environment.CommandLine.IndexOf("--encoding-priority") < Environment.CommandLine.IndexOf("--dfn-priority")
                 ? videoTracks
                     .OrderBy(v => encodingPriority.TryGetValue(v.codecs, out byte i) ? i : 100)
@@ -967,7 +967,7 @@ namespace BBDown
                 QRCodeData qrCodeData = qrGenerator.CreateQrCode(url, QRCodeGenerator.ECCLevel.Q);
                 PngByteQRCode pngByteCode = new(qrCodeData);
                 File.WriteAllBytes("qrcode.png", pngByteCode.GetGraphic(7));
-                Log("生成二维码成功：qrcode.png, 请打开并扫描, 或扫描打印的二维码");
+                Log("生成二维码成功: qrcode.png, 请打开并扫描, 或扫描打印的二维码");
                 var consoleQRCode = new ConsoleQRCode(qrCodeData);
                 consoleQRCode.GetGraphic();
 
@@ -1024,7 +1024,7 @@ namespace BBDown
                 QRCodeData qrCodeData = qrGenerator.CreateQrCode(url, QRCodeGenerator.ECCLevel.Q);
                 PngByteQRCode pngByteCode = new(qrCodeData);
                 File.WriteAllBytes("qrcode.png", pngByteCode.GetGraphic(7));
-                Log("生成二维码成功：qrcode.png, 请打开并扫描, 或扫描打印的二维码");
+                Log("生成二维码成功: qrcode.png, 请打开并扫描, 或扫描打印的二维码");
                 var consoleQRCode = new ConsoleQRCode(qrCodeData);
                 consoleQRCode.GetGraphic();
                 parms.Set("auth_code", authCode);

--- a/README.md
+++ b/README.md
@@ -4,23 +4,23 @@
 一款命令行式哔哩哔哩下载器. Bilibili Downloader.
 
 # 注意
-本软件混流时需要外部程序：
+本软件混流时需要外部程序:
 
-* 普通视频：[ffmpeg](https://www.gyan.dev/ffmpeg/builds/) ，或 [mp4box](https://gpac.wp.imt.fr/downloads/)
-* 杜比视界：ffmpeg5.0以上或新版mp4box.
+* 普通视频: [ffmpeg](https://www.gyan.dev/ffmpeg/builds/), 或 [mp4box](https://gpac.wp.imt.fr/downloads/)
+* 杜比视界: ffmpeg5.0以上或新版mp4box.
 
 # 快速开始
-本软件已经以 [Dotnet Tool](https://www.nuget.org/packages/BBDown/) 形式发布  
+本软件已经以 [Dotnet Tool](https://www.nuget.org/packages/BBDown/) 形式发布
 
-如果你本地有dotnet环境，使用如下命令即可安装使用
+如果你本地有dotnet环境, 使用如下命令即可安装使用
 ```
 dotnet tool install --global BBDown
 ```
 
 # 下载
-Release版本：https://github.com/nilaoda/BBDown/releases
+Release版本: https://github.com/nilaoda/BBDown/releases
 
-自动构建的测试版本：https://github.com/nilaoda/BBDown/actions
+自动构建的测试版本: https://github.com/nilaoda/BBDown/actions
 
 # 开始使用
 目前命令行参数支持情况
@@ -128,19 +128,19 @@ Commands:
 # 使用教程
 
 <details>
-<summary>配置文件 (NEW)</summary> 
+<summary>配置文件 (NEW)</summary>
 
 ---
 
-在`1.4.9`或更高版本中，BBDown支持读取本地配置文件以简化命令行的手动输入。
+在`1.4.9`或更高版本中, BBDown支持读取本地配置文件以简化命令行的手动输入。
 
-如果用户没有指定`--config-file`，则默认读取程序同目录下的`BBDown.config`文件；若用户指定，则读取特定文件。
+如果用户没有指定`--config-file`, 则默认读取程序同目录下的`BBDown.config`文件；若用户指定, 则读取特定文件。
 
 一个典型的配置文件:
 ```config
 #本文件是BBDown程序的配置文件
 #以#开头的都会被程序忽略
-#然后剩余非空白内容程序逐行读取，对于一个选项，其参数应当在下一行出现
+#然后剩余非空白内容程序逐行读取, 对于一个选项, 其参数应当在下一行出现
 
 #例如下面将设置输出文件名格式
 --file-pattern
@@ -149,7 +149,7 @@ Commands:
 --multi-file-pattern
 <videoTitle>/[P<pageNumberWithZero>]<pageTitle>[<dfn>]
 
-#下面设置下载多个分P时，每个分P的下载间隔为2秒
+#下面设置下载多个分P时, 每个分P的下载间隔为2秒
 --delay-per-page
 2
 
@@ -160,11 +160,11 @@ Commands:
 </details>
 
 <details>
-<summary>自定义输出文件名格式 (NEW)</summary> 
+<summary>自定义输出文件名格式 (NEW)</summary>
 
 ---
 
-在`1.4.9`或更高版本中，BBDown支持用户自定义合并时的文件名组成。
+在`1.4.9`或更高版本中, BBDown支持用户自定义合并时的文件名组成。
 |  代码   | 含义  |
 |  ----  | ----  |
 `<videoTitle>`|视频主标题
@@ -180,35 +180,35 @@ Commands:
 `<videoBandwidth>`|视频码率
 `<audioCodecs>`|音频编码
 `<audioBandwidth>`|音频码率
-`<ownerName>`|上传者名称(下载番剧时，该值为"")
-`<ownerMid>`|上传者mid(下载番剧时，该值为"")
+`<ownerName>`|上传者名称(下载番剧时, 该值为"")
+`<ownerMid>`|上传者mid(下载番剧时, 该值为"")
 
 </details>
 
 <details>
-<summary>WEB/TV鉴权</summary>  
+<summary>WEB/TV鉴权</summary>
 
 ---
-  
-扫码登录网页账号：
+
+扫码登录网页账号:
 ```
 BBDown login
 ```
 然后按照提示操作
 
-扫码登录云视听小电视账号：
+扫码登录云视听小电视账号:
 ```
 BBDown logintv
 ```
 然后按照提示操作
- 
-*PS: 如果登录报错`The type initializer for 'Gdip' threw an exception`，请参考 [#37](https://github.com/nilaoda/BBDown/issues/37) 解决*
 
-手动加载网页cookie：
+*PS: 如果登录报错`The type initializer for 'Gdip' threw an exception`, 请参考 [#37](https://github.com/nilaoda/BBDown/issues/37) 解决*
+
+手动加载网页cookie:
 ```
 BBDown -c "SESSDATA=******" "https://www.bilibili.com/video/BV1qt4y1X7TW"
 ```
-手动加载云视听小电视token：
+手动加载云视听小电视token:
 ```
 BBDown -tv -token "******" "https://www.bilibili.com/video/BV1qt4y1X7TW"
 ```
@@ -216,18 +216,18 @@ BBDown -tv -token "******" "https://www.bilibili.com/video/BV1qt4y1X7TW"
 </details>
 
 <details>
-<summary>APP鉴权</summary>  
+<summary>APP鉴权</summary>
 
 ---
 
-> 根据 [#123](https://github.com/nilaoda/BBDown/issues/123#issuecomment-877583825) ，可以填写TV登录产生的`access_token`来给APP接口使用。可复制`BBDownTV.data`到`BBDownApp.data`使程序自动读取.
+> 根据 [#123](https://github.com/nilaoda/BBDown/issues/123#issuecomment-877583825) , 可以填写TV登录产生的`access_token`来给APP接口使用。可复制`BBDownTV.data`到`BBDownApp.data`使程序自动读取.
 
-目前程序无法自动获取鉴权信息，推荐通过**抓包**来获取.
+目前程序无法自动获取鉴权信息, 推荐通过**抓包**来获取.
 
-在请求Header中寻找键为`authorization`的项，其值形为`identify_v1 5227************1`，其中的`5227************1`就是token(access_key)
+在请求Header中寻找键为`authorization`的项, 其值形为`identify_v1 5227************1`, 其中的`5227************1`就是token(access_key)
 
 获取后手动通过`-token`命令加载, 或写入`BBDownApp.data`使程序自动读取.
-  
+
 ```
 BBDown -app -token "******" "https://www.bilibili.com/video/BV1qt4y1X7TW"
 ```
@@ -235,37 +235,37 @@ BBDown -app -token "******" "https://www.bilibili.com/video/BV1qt4y1X7TW"
 </details>
 
 <details>
-<summary>常用命令</summary>  
+<summary>常用命令</summary>
 
 ---
 
-下载普通视频：
+下载普通视频:
 ```
 BBDown "https://www.bilibili.com/video/BV1qt4y1X7TW"
 ```
-使用TV接口下载(粉丝量大的UP主基本上是无水印片源)：
+使用TV接口下载(粉丝量大的UP主基本上是无水印片源):
 ```
 BBDown -tv "https://www.bilibili.com/video/BV1qt4y1X7TW"
 ```
-当分P过多时，默认会隐藏展示全部的分P信息，你可以使用如下命令来显示所有每一个分P。
+当分P过多时, 默认会隐藏展示全部的分P信息, 你可以使用如下命令来显示所有每一个分P。
 ```
 BBDown --show-all "https://www.bilibili.com/video/BV1At41167aj"
 ```
-选择下载某些分P的三种情况：
-* 单个分P：10
+选择下载某些分P的三种情况:
+* 单个分P: 10
 ```
 BBDown "https://www.bilibili.com/video/BV1At41167aj?p=10"
 BBDown -p 10 "https://www.bilibili.com/video/BV1At41167aj"
 ```
-* 多个分P：1,2,10
+* 多个分P: 1,2,10
 ```
 BBDown -p 1,2,10 "https://www.bilibili.com/video/BV1At41167aj"
 ```
-* 范围分P：1-10
+* 范围分P: 1-10
 ```
 BBDown -p 1-10 "https://www.bilibili.com/video/BV1At41167aj"
 ```
-下载番剧全集：
+下载番剧全集:
 ```
 BBDown -p ALL "https://www.bilibili.com/bangumi/play/ss33073"
 ```
@@ -275,7 +275,7 @@ BBDown -p ALL "https://www.bilibili.com/bangumi/play/ss33073"
 # 演示
 ![1](https://user-images.githubusercontent.com/20772925/88686407-a2001480-d129-11ea-8aac-97a0c71af115.gif)
 
-下载完毕后在当前目录查看MP4文件：
+下载完毕后在当前目录查看MP4文件:
 
 ![2](https://user-images.githubusercontent.com/20772925/88478901-5e1cdc00-cf7e-11ea-97c1-154b9226564e.png)
 


### PR DESCRIPTION
ffmpeg早已能够根据后缀自动判断文件类型, 移除 '-f mp4' 使 m4a 的 Codec ID 为 'M4A/isom/iso2' 而不是 'isom/iso2/mp41'