### PR TITLE
Fix #548

### DIFF
--- a/BBDown/BBDownMuxer.cs
+++ b/BBDown/BBDownMuxer.cs
@@ -88,7 +88,7 @@ namespace BBDown
             }
 
             //----分析完毕
-            var arguments = inputArg.ToString() + (metaArg.ToString() == "" ? "" : " -itags tool=" + metaArg.ToString()) + $" -new \"{outPath}\"";
+            var arguments = inputArg.ToString() + (metaArg.ToString() == "" ? "" : " -itags tool=" + metaArg.ToString()) + $" -new -- \"{outPath}\"";
             LogDebug("mp4box命令：{0}", arguments);
             return RunExe(MP4BOX, arguments, MP4BOX != "mp4box");
         }
@@ -158,7 +158,7 @@ namespace BBDown
                  $"-c copy " + (audioOnly && audioPath == "" ? " -vn " : "") +
                  (subs != null ? " -c:s mov_text " : "") +
                  "-movflags faststart -strict unofficial -strict -2 -f mp4 " +
-                 $"\"{outPath}\"";
+                 $"-- \"{outPath}\"";
             LogDebug("ffmpeg命令：{0}", arguments);
             return RunExe(FFMPEG, arguments, FFMPEG != "ffmpeg");
         }


### PR DESCRIPTION
当视频名称以 `-` 开头时，音视频合并会失败。以 #548 为例，最终程序生成的合并视频的命令行参数如下：

```
ffmpeg -loglevel warning -y  -i "762058039/762058039.P1.380418735.mp4"  -i "762058039/762058039.P1.380418735.m4a"  -i "762058039/762058039.jpg"  -map 0  -map 1  -map 2  -disposition:v:1 attached_pic  -metadata title="-魔法少女传奇ABC
第10集    让我们成为一个..._fix" -metadata description="本视频已取得作者独家合作授权，自制投稿为作者意愿。rn全网仅在bilibili发布，禁止在站内或其他平台搬运！rn视频绝大部分收益会转账给作者，以便支持作者后续创作。rn您的三连支持就是我们创作更新的最大动力！rn漫画地址：https://openbook.kr/content/710/listview/128rn作者主页：https://www.youtube.com/channel/UCYwxmi2bpkvzqvyB2VoUr8g" -metadata artist="哲士狗荔枝" -c copy  -c:s mov_text -movflags faststart -strict unofficial -strict -2 -f mp4 "-魔法少女传奇ABC 第10集    让我们成为一个..._fix.mp4"
```

ffmpeg 在处理如下参数时：

```
-f mp4 "-魔法少女传奇ABC 第10集    让我们成为一个..._fix.mp4"
```

看到文件名开头的 `-` 时，会把它也错误地解析为一个命令行参数，进而导致视频合并失败。

![图片](https://user-images.githubusercontent.com/5435649/229330511-937ac7f4-3edf-4c92-b9b8-f53937812d19.png)

解决方案：

方案一：

```
-f mp4 -- "-魔法少女传奇ABC 第10集    让我们成为一个..._fix.mp4"
```

方案二：

```
-f mp4 "./-魔法少女传奇ABC 第10集    让我们成为一个..._fix.mp4"
```

参考：

- [File name beginning with - (dash) [duplicate]](https://unix.stackexchange.com/questions/249931/file-name-beginning-with-dash)
- [Why does my shell script choke on whitespace or other special characters?](https://unix.stackexchange.com/questions/131766/why-does-my-shell-script-choke-on-whitespace-or-other-special-characters)