### PR TITLE
使用BBDown.dll文件所在位置作为APP_DIR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -360,3 +360,5 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+dist/
+.idea/

--- a/BBDown/BBDown.csproj
+++ b/BBDown/BBDown.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Version>1.5.7</Version>
     <Description>BBDown是一个免费且便捷高效的哔哩哔哩下载/解析软件.</Description>
@@ -12,6 +12,7 @@
     <ToolCommandName>BBDown</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <Nullable>enable</Nullable>
+    <SelfContained>false</SelfContained>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BBDown/Program.cs
+++ b/BBDown/Program.cs
@@ -23,7 +23,6 @@ using BBDown.Core.Fetcher;
 using System.Text.Json.Serialization;
 using System.CommandLine.Binding;
 using System.CommandLine.Builder;
-using System.Reflection;
 
 namespace BBDown
 {
@@ -33,7 +32,7 @@ namespace BBDown
         public static string SinglePageDefaultSavePath { get; set; } = "<videoTitle>";
         public static string MultiPageDefaultSavePath { get; set; } = "<videoTitle>/[P<pageNumberWithZero>]<pageTitle>";
 
-        public readonly static string APP_DIR = Path.GetDirectoryName(Assembly.GetCallingAssembly().Location)!;
+        public readonly static string APP_DIR = Path.GetDirectoryName(System.AppContext.BaseDirectory)!;
 
         private static int Compare(Audio r1, Audio r2)
         {

--- a/BBDown/Program.cs
+++ b/BBDown/Program.cs
@@ -23,6 +23,7 @@ using BBDown.Core.Fetcher;
 using System.Text.Json.Serialization;
 using System.CommandLine.Binding;
 using System.CommandLine.Builder;
+using System.Reflection;
 
 namespace BBDown
 {
@@ -32,7 +33,7 @@ namespace BBDown
         public static string SinglePageDefaultSavePath { get; set; } = "<videoTitle>";
         public static string MultiPageDefaultSavePath { get; set; } = "<videoTitle>/[P<pageNumberWithZero>]<pageTitle>";
 
-        public readonly static string APP_DIR = Path.GetDirectoryName(Environment.ProcessPath)!;
+        public readonly static string APP_DIR = Path.GetDirectoryName(Assembly.GetCallingAssembly().Location)!;
 
         private static int Compare(Audio r1, Audio r2)
         {
@@ -109,12 +110,12 @@ namespace BBDown
                 return 1;
             }
 
-            if (commandLineResult.CommandResult.Command.Name.ToLower() != Path.GetFileNameWithoutExtension(Environment.ProcessPath)!.ToLower())
-            {
-                newArgsList.Add(commandLineResult.CommandResult.Command.Name);
-                return await parser.InvokeAsync(newArgsList.ToArray());
-            }
-
+            // if (commandLineResult.CommandResult.Command.Name.ToLower() != Path.GetFileNameWithoutExtension(Environment.ProcessPath)!.ToLower())
+            // {
+            //     newArgsList.Add(commandLineResult.CommandResult.Command.Name);
+            //     return await parser.InvokeAsync(newArgsList.ToArray());
+            // }
+            
             foreach (var item in commandLineResult.CommandResult.Children)
             {
                 if (item is ArgumentResult a)


### PR DESCRIPTION
当使用ProcessPath作为APP_DIR时，使用`dotnet BBDown.dll`会导致APP_DIR变成dotnet所在位置而不是BBDown.dll所在位置

使用`Assembly.GetCallingAssembly().Location`替换即可