### PR TITLE
Fix: allow dot(.) and dash(-) in file pattern

### DIFF
--- a/BBDown/Program.cs
+++ b/BBDown/Program.cs
@@ -842,7 +842,7 @@ namespace BBDown
             return result;
         }
 
-        [GeneratedRegex("<([\\w:]+?)>")]
+        [GeneratedRegex("<([\\w:\\-.]+?)>")]
         private static partial Regex InfoRegex();
     }
 }


### PR DESCRIPTION
支持在 file pattern 中使用 `.` 或者 `-`

例如
```conf 
# 2024-01-25
<publishDate:yyyy-MM-dd>

# 2024.01.25
<publishDate:yyyy.MM.dd>
```