### PR TITLE
优化课程和番剧 EP/SS ID 解析，提升用户体验

### DIFF
--- a/BBDown/BBDownUtil.cs
+++ b/BBDown/BBDownUtil.cs
@@ -84,12 +84,12 @@ namespace BBDown
                     string epId = await GetEpIdByBangumiSSIdAsync(SsRegex().Match(input).Groups[1].Value);
                     avid = $"ep:{epId}";
                 }
-                else if (input.Contains("/medialist/") && input.Contains("business_id=") && input.Contains("business=space_collection")) //列表类型是合集
+                else if (input.Contains("/medialist/") && input.Contains("business_id=") && input.Contains("business=space_collection")) // 列表类型是合集
                 {
                     string bizId = GetQueryString("business_id", input);
                     avid = $"listBizId:{bizId}";
                 }
-                else if (input.Contains("/medialist/") && input.Contains("business_id=") && input.Contains("business=space_series")) //列表类型是系列
+                else if (input.Contains("/medialist/") && input.Contains("business_id=") && input.Contains("business=space_series")) // 列表类型是系列
                 {
                     string bizId = GetQueryString("business_id", input);
                     avid = $"seriesBizId:{bizId}";
@@ -145,9 +145,22 @@ namespace BBDown
             {
                 avid = GetAidByBV(input[3..]);
             }
-            else if (input.ToLower().StartsWith("av")) //av
+            else if (input.ToLower().StartsWith("av")) // av
             {
                 avid = input.ToLower()[2..];
+            }
+            else if (input.StartsWith("cheese/")) // cheese/(ep|ss)\d+ 格式
+            {
+                string epId = "";
+                if (input.Contains("/ep"))
+                {
+                    epId = EpRegex().Match(input).Groups[1].Value;
+                }
+                else if (input.Contains("/ss"))
+                {
+                    epId = await GetEpidBySSIdAsync(SsRegex().Match(input).Groups[1].Value);
+                }
+                avid = $"cheese:{epId}";
             }
             else if (input.StartsWith("ep"))
             {

--- a/BBDown/BBDownUtil.cs
+++ b/BBDown/BBDownUtil.cs
@@ -149,7 +149,7 @@ namespace BBDown
             {
                 avid = input.ToLower()[2..];
             }
-            else if (input.StartsWith("cheese/")) // cheese/(ep|ss)\d+ 格式
+            else if (input.StartsWith("cheese/")) // ^cheese/(ep|ss)\d+ 格式
             {
                 string epId = "";
                 if (input.Contains("/ep"))

--- a/BBDown/Program.cs
+++ b/BBDown/Program.cs
@@ -226,13 +226,13 @@ namespace BBDown
 
         public static async Task<(string fetchedAid, VInfo vInfo, string apiType)> GetVideoInfoAsync(MyOption myOption, string aidOri, string input)
         {
-			Log("检测账号登录...");
+            Log("检测账号登录...");
 
             // 加载认证信息
             LoadCredentials(myOption);
 
-			// 检测是否登录了账号
-			bool is_login = await CheckLogin(Config.COOKIE);
+            // 检测是否登录了账号
+            bool is_login = await CheckLogin(Config.COOKIE);
             if (!myOption.UseIntlApi && !myOption.UseTvApi && Config.AREA == "")
             {
                 if (!is_login)
@@ -240,7 +240,7 @@ namespace BBDown
                     LogWarn("你尚未登录B站账号, 解析可能受到限制");
                 }
             }
-            
+
             Log("获取aid...");
             aidOri = await GetAvIdAsync(input);
             Log("获取aid结束: " + aidOri);
@@ -267,16 +267,17 @@ namespace BBDown
                 LogWarn("未找到此 EP/SS 对应番剧信息, 正在尝试按课程查找。");
 
                 aidOri = aidOri.Replace("ep", "cheese");
-				Log("新的 aid: " + aidOri);
+                Log("新的 aid: " + aidOri);
 
-				if (string.IsNullOrEmpty(aidOri)) {
-					throw new Exception("输入有误");
-				}
+                if (string.IsNullOrEmpty(aidOri))
+                {
+                    throw new Exception("输入有误");
+                }
 
-				Log("获取视频信息...");
-				fetcher = FetcherFactory.CreateFetcher(aidOri, myOption.UseIntlApi);
-				vInfo = await fetcher.FetchAsync(aidOri);
-			}
+                Log("获取视频信息...");
+                fetcher = FetcherFactory.CreateFetcher(aidOri, myOption.UseIntlApi);
+                vInfo = await fetcher.FetchAsync(aidOri);
+            }
 
             string title = vInfo.Title;
             long pubTime = vInfo.PubTime;


### PR DESCRIPTION
## 主要更改

1. 增强 `GetVideoInfoAsync` 方法：
   - 当只输入 EP/SS ID 时，先尝试按番剧查找，如果找不到则尝试按课程查找
   - 添加了相应的错误处理和日志输出，提高用户体验
2. 扩展 `GetAvIdAsync` 方法：
   - 新增对 `^cheese/(ep|ss)\d+` 格式的支持（正则表达式仅作为提示）
3. 代码优化：
   - 更新了部分注释，提高代码可读性
   - 微调了日志输出的位置，使其更加合理

## 技术细节

- 在 `GetVideoInfoAsync` 中，通过捕获 `KeyNotFoundException` 来判断是否需要尝试按课程查找
- 在 `GetAvIdAsync` 中，新增了对 `cheese/` 开头 URL 的处理逻辑

## 未来优化建议

1. 考虑添加 `.editorconfig` 文件，规范化代码格式，便于不同开发者在各自的 IDE 或编辑器中保持一致的代码风格
2. 建议使用代码分析工具（如 DeepSource）和 Visual Studio 的分析功能，处理项目中的警告和提示，进一步提高代码质量

## 测试

- [x] 测试番剧 EP/SS ID 解析（测试了 `ep5737` 和 `ss281`）
- [x] 测试课程 EP/SS ID 解析（测试了 `ep125811` `cheese/ep125811` `ep6173` `cheese/ep6173` 和 `cheese/ss281`）
- [x] 测试其他现有功能，确保未受影响（测试了几个完整的课程 EP URL）

## 相关问题

- 解决了用户在输入课程 EP/SS ID 时遇到的解析失败问题 Fix #764