### PR TITLE
Correct console encoding to display Unicode characters properly

### DIFF
--- a/BBDown/Program.cs
+++ b/BBDown/Program.cs
@@ -13,6 +13,7 @@ using static BBDown.BBDownDownloadUtil;
 using static BBDown.Core.Parser;
 using static BBDown.Core.Logger;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using BBDown.Core;
@@ -68,6 +69,8 @@ namespace BBDown
 
         public static async Task<int> Main(params string[] args)
         {
+            // Set the console output encoding to UTF-8
+            Console.OutputEncoding = Encoding.UTF8;
             Console.CancelKeyPress += Console_CancelKeyPress;
             ServicePointManager.DefaultConnectionLimit = 2048;
 


### PR DESCRIPTION
When running BBDown results in multiple "???" characters in the console output, especially when displaying Unicode characters such as Chinese text. This issue hinders readability and usability of the application.