### PR TITLE
fix(mux): handle macOS hevc video tag, hev1 -> hvc1(Quicklook Supported)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -366,3 +366,11 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# debug log
+debug_*.json
+
+# dotnet run in `BBDown/` sub folder
+/BBDown/*.mp4
+/BBDown/*.xml
+/BBDown/*.ass

--- a/BBDown/BBDownMuxer.cs
+++ b/BBDown/BBDownMuxer.cs
@@ -9,6 +9,7 @@ using static BBDown.Core.Util.SubUtil;
 using static BBDown.Core.Logger;
 using System.IO;
 using BBDown.Core;
+using System.Runtime.InteropServices;
 
 namespace BBDown;
 
@@ -96,7 +97,7 @@ static partial class BBDownMuxer
         return RunExe(MP4BOX, arguments, MP4BOX != "mp4box");
     }
 
-    public static int MuxAV(bool useMp4box, string bvid, string videoPath, string audioPath, List<AudioMaterial> audioMaterial, string outPath, string desc = "", string title = "", string author = "", string episodeId = "", string pic = "", string lang = "", List<Subtitle>? subs = null, bool audioOnly = false, bool videoOnly = false, List<ViewPoint>? points = null, long pubTime = 0, bool simplyMux = false)
+    public static int MuxAV(bool useMp4box, string bvid, string videoPath, string audioPath, List<AudioMaterial> audioMaterial, string outPath, string desc = "", string title = "", string author = "", string episodeId = "", string pic = "", string lang = "", List<Subtitle>? subs = null, bool audioOnly = false, bool videoOnly = false, List<ViewPoint>? points = null, long pubTime = 0, bool simplyMux = false, bool isHevc = false)
     {
         if (audioOnly && audioPath != "")
             videoPath = "";
@@ -191,6 +192,8 @@ static partial class BBDownMuxer
         argsBuilder.Append("-c copy ");
         if (audioOnly && audioPath == "") argsBuilder.Append("-vn ");
         if (subs != null) argsBuilder.Append("-c:s mov_text ");
+        // fix macOS hev1, see https://discussions.apple.com/thread/253081863?sortBy=rank
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && isHevc) argsBuilder.Append("-tag:v:0 hvc1 ");
         argsBuilder.Append($"-movflags faststart -strict unofficial -strict -2 -f mp4 -- \"{outPath}\"");
 
         string arguments = argsBuilder.ToString();

--- a/BBDown/Program.cs
+++ b/BBDown/Program.cs
@@ -669,6 +669,8 @@ partial class Program
                 Log($"开始合并音视频{(subtitleInfo.Any() ? "和字幕" : "")}...");
                 if (myOption.AudioOnly)
                     savePath = savePath[..^4] + ".m4a";
+
+                var isHevc = selectedVideo?.codecs == "HEVC";
                 int code = BBDownMuxer.MuxAV(myOption.UseMP4box, p.bvid, videoPath, audioPath, audioMaterial, savePath,
                     desc,
                     title,
@@ -676,7 +678,7 @@ partial class Program
                     (pagesCount > 1 || (bangumi && !vInfo.IsBangumiEnd)) ? p.title : "",
                     File.Exists(coverPath) ? coverPath : "",
                     lang,
-                    subtitleInfo, myOption.AudioOnly, myOption.VideoOnly, p.points, p.pubTime, myOption.SimplyMux);
+                    subtitleInfo, myOption.AudioOnly, myOption.VideoOnly, p.points, p.pubTime, myOption.SimplyMux, isHevc);
                 if (code != 0 || !File.Exists(savePath) || new FileInfo(savePath).Length == 0)
                 {
                     LogError("合并失败"); return;


### PR DESCRIPTION
fix hevc 视频在 macOS 上不能预览的问题.

hevc tag 可以从 ffprobe 结果中看出
```
// hev1 视频的 ffprobe 输出. (❌ QuickLook NOT supported) 
Stream #0:0[0x1](und): Video: hevc (Main) (hev1 / 0x31766568)

// hvc1 视频的 ffprobe 输出. (✅ QuickLook supported)
Stream #0:0[0x1](und): Video: hevc (Main) (hvc1 / 0x31637668)
```

而 B 站下载的恰好都是 macOS Quicklook 不支持的 hev1, 通过 `-tag:v:0 hvc1` 转成 hvc1 即可, 不涉及重新 encode


---
demo

现有
![bbdown-fix-hevc-1](https://github.com/user-attachments/assets/df0acdbd-89d2-49b3-a320-28c31caf23e7)



fix后
![bbdown-fix-hevc-2](https://github.com/user-attachments/assets/14203e47-675d-461a-a00b-ba25273ae50f)

