### PR TITLE
Feat: Add docker image release workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,59 @@
+name: Docker Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release:
+        description: "tag (e.g., 1.6.3)"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  docker-release:
+    runs-on: ubuntu-latest
+    env:
+      WORKDIR: ${{ github.workspace }}
+      RELEASE: ${{ github.event.inputs.release || github.event.release.tag_name }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - uses: dsaltares/fetch-gh-release-asset@master
+        with:
+          # 指定tag下载已构建完成的制品
+          version: 'tags/${{ github.event.inputs.release || github.event.release.tag_name }}'
+          file: 'BBDown_linux-.*.zip'
+          regex: true
+          target: 'artifact/'
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Show Artifact
+        run: pwd;ls;ls -l ./artifact/
+
+      - name: echo env
+        run: echo ${RELEASE};echo ${DOCKER_LOGIN};echo ${WORKDIR}
+
+      - name: Docker login
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  # v3.3.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ github.workspace }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/bbdown:${{ github.event.inputs.release || github.event.release.tag_name }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/bbdown:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM alpine:latest AS builder
+COPY artifact/ /opt/
+
+RUN apk update \
+    && apk add unzip file \
+    && if [ $(arch) == "aarch64" ]; then \
+         unzip /opt/BBDown_*_linux-arm64.zip -d /; \
+       elif [ $(arch) == "x86_64" ]; then \
+         unzip /opt/BBDown_*_linux-x64.zip -d /; \
+       fi \
+    && file /BBDown
+
+
+FROM ubuntu:25.04
+
+COPY --from=builder /BBDown /BBDown
+
+RUN apt-get -y update \
+    && apt-get -y upgrade \
+    && apt-get install -y --no-install-recommends ffmpeg \
+    && apt-get clean
+
+EXPOSE 23333
+
+ENTRYPOINT ["/BBDown", "serve", "-l", "http://0.0.0.0:23333"]

--- a/README.md
+++ b/README.md
@@ -309,6 +309,41 @@ API服务器不支持HTTPS配置，如果有需要请自行使用nginx等反向�
 API详细请参考[json-api-doc.md](./json-api-doc.md)
 </details>
 
+<details>
+<summary>Docker运行</summary>
+
+启动服务器
+1. 拉取镜像
+    ```bash
+    docker pull nilaoda/bbdown:1.6.3
+    ```
+
+2. 运行
+    ```bash
+    docker run -dit \
+      --name bbdown-serve \
+      --restart=always \
+      -v ${PWD}/downloads:/downloads \
+      -p 23333:23333 \
+      nilaoda/bbdown:1.6.3
+   
+    # 带Cookie运行服务器
+    docker run -dit \
+      --name bbdown-serve \
+      --restart=always \
+      -v ${PWD}/BBDown.data:/BBDown.data \
+      -v ${PWD}/downloads:/downloads \
+      -p 23333:23333 \
+      nilaoda/bbdown:1.6.3
+    ```
+
+3. 查看日志
+    ```bash
+    docker logs -f --tail=200 bbdown-serve
+    ```
+   
+</details>
+
 # 演示
 ![1](https://user-images.githubusercontent.com/20772925/88686407-a2001480-d129-11ea-8aac-97a0c71af115.gif)
 


### PR DESCRIPTION
## About This PR
- [x] 新增workflow，创建Release后触发，使用当前tag制品构建docker镜像并推送至[DockerHub](https://hub.docker.com)，linux/arm64和linux/amd64两个架构。
- [x] 除Release触发外， 也支持手动指定`tag`运行该workflow。
- [x] 新增docker镜像使用说明。

## 依赖说明
1. 需要仓库管理员配置repository secrets，新增`DOCKERHUB_USERNAME`和`DOCKERHUB_PASSWORD`
2. 上面的`DOCKERHUB_USERNAME` 我先入为主，用作者github id `nilaoda`写到了README.md中，作者可以修改为自己的dockerhub账号，以及相关文档内容


## 效果图
![image](https://github.com/user-attachments/assets/0242716d-cbab-42df-9ab6-cb6fdc40c4dd)
<img width="707" alt="image" src="https://github.com/user-attachments/assets/f1f487ca-3911-4af2-ac7b-f3d46e014434" />


做好发现已经有个小伙伴提了[PR](https://github.com/nilaoda/BBDown/pull/951)，作者酌情合并即可
