### PR TITLE
fix: 修复arm平台apt仓库404问题

### DIFF
--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -60,6 +60,46 @@ jobs:
     needs: set-date
 
     steps:
+      - name: setup deb822 repos
+        run: |
+          if [[ $ImageOS == "ubuntu24" ]]; then
+            cat <<EOF > deb822sources
+          Types: deb
+          URIs: http://archive.ubuntu.com/ubuntu/
+          Suites: noble
+          Components: main restricted universe
+          Architectures: amd64
+
+          Types: deb
+          URIs: http://security.ubuntu.com/ubuntu/
+          Suites: noble-security
+          Components: main restricted universe
+          Architectures: amd64
+
+          Types: deb
+          URIs: http://archive.ubuntu.com/ubuntu/
+          Suites: noble-updates
+          Components: main restricted universe
+          Architectures: amd64
+
+          Types: deb
+          URIs: http://azure.ports.ubuntu.com/ubuntu-ports/
+          Suites: noble
+          Components: main restricted multiverse universe
+          Architectures: arm64
+
+          Types: deb
+          URIs: http://azure.ports.ubuntu.com/ubuntu-ports/
+          Suites: noble-updates
+          Components: main restricted multiverse universe
+          Architectures: arm64
+          EOF
+
+            sudo mv deb822sources /etc/apt/sources.list.d/ubuntu.sources
+          else
+            sudo mv config/crosscomp-sources.list /etc/apt/sources.list
+          fi
+
       # https://learn.microsoft.com/zh-cn/dotnet/core/deploying/native-aot/cross-compile
       - run: |
           sudo dpkg --add-architecture arm64
@@ -72,7 +112,7 @@ jobs:
           sudo sed -i -e 's/deb mirror/deb [arch=amd64] mirror/g' /etc/apt/sources.list
           sudo apt-get update
           sudo apt-get install -y curl wget libicu-dev libcurl4-openssl-dev zlib1g-dev libkrb5-dev clang llvm binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu zlib1g-dev:arm64
-      
+
       - uses: actions/checkout@v1
 
       - name: Set up dotnet
@@ -133,7 +173,7 @@ jobs:
         with:
           name: BBDown_osx-x64
           path: BBDown_${{ needs.set-date.outputs.date }}_osx-x64.zip
-          
+
       - name: Upload Artifact [osx-arm64]
         uses: actions/upload-artifact@v3.1.3
         with:


### PR DESCRIPTION
## 背景
fork仓库后触发build latest actions发现[build-linux-x64-arm64](https://github.com/nilaoda/BBDown/blob/master/.github/workflows/build_latest.yml#L58C3-L58C24)运行报错。

```text
...
Err:7 http://security.ubuntu.com/ubuntu noble/main arm64 Packages
  404  Not Found [IP: 20.106.104.242 80]
Err:8 http://security.ubuntu.com/ubuntu noble/universe arm64 Packages
  404  Not Found [IP: 20.106.104.242 80]
Err:9 http://security.ubuntu.com/ubuntu noble/restricted arm64 Packages
  404  Not Found [IP: 20.106.104.242 80]
Err:10 http://security.ubuntu.com/ubuntu noble/multiverse arm64 Packages
  404  Not Found [IP: 20.106.104.242 80]
Err:12 http://security.ubuntu.com/ubuntu noble-updates/main arm64 Packages
  404  Not Found [IP: 20.106.104.242 80]
  404  Not Found [IP: 20.106.104.242 80]
Err:21 http://security.ubuntu.com/ubuntu noble-updates/restricted arm64 Packages
  404  Not Found [IP: 20.106.104.242 80]
Err:24 http://security.ubuntu.com/ubuntu noble-updates/multiverse arm64 Packages
  404  Not Found [IP: 20.106.104.242 80]
Err:27 http://security.ubuntu.com/ubuntu noble-backports/universe arm64 Packages
  404  Not Found [IP: 20.106.104.242 80]
Err:32 http://security.ubuntu.com/ubuntu noble-security/main arm64 Packages
  404  Not Found [IP: 20.106.104.242 80]
Err:35 http://security.ubuntu.com/ubuntu noble-security/universe arm64 Packages
  404  Not Found [IP: 20.106.104.242 80]
Err:39 http://security.ubuntu.com/ubuntu noble-security/restricted arm64 Packages
  404  Not Found [IP: 20.106.104.242 80]
Err:44 http://security.ubuntu.com/ubuntu noble-security/multiverse arm64 Packages
  404  Not Found [IP: 20.106.104.242 80]
Err:9 http://security.ubuntu.com/ubuntu noble/restricted arm64 Packages
  404  Not Found [IP: 20.106.104.242 80]
Err:32 http://security.ubuntu.com/ubuntu noble-security/main arm64 Packages
  404  Not Found [IP: 20.106.104.242 80]
Ign:35 http://security.ubuntu.com/ubuntu noble-security/universe arm64 Packages
Ign:39 http://security.ubuntu.com/ubuntu noble-security/restricted arm64 Packages
Ign:44 http://security.ubuntu.com/ubuntu noble-security/multiverse arm64 Packages
Fetched 14.6 MB in 12s (1[259](https://github.com/nilaoda/BBDown/actions/runs/12750345856/job/35534876674#step:2:260) kB/s)
Reading package lists...
E: Failed to fetch http://security.ubuntu.com/ubuntu/dists/noble/main/binary-arm64/Packages  404  Not Found [IP: 20.106.104.242 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/dists/noble-updates/main/binary-arm64/Packages  404  Not Found [IP: 20.106.104.242 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/dists/noble-backports/universe/binary-arm64/Packages  404  Not Found [IP: 20.106.104.242 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/dists/noble-security/main/binary-arm64/Packages  404  Not Found [IP: 20.106.104.242 80]
E: Some index files failed to download. They have been ignored, or old ones used instead.
Error: Process completed with exit code 100.
...
```

## 解决方法
actions官仓[issue](https://github.com/actions/runner-images/issues/10901#issuecomment-2474123569)，已验证可正确[运行](https://github.com/XuHandsome/BBDown/actions/runs/12760288360)