### PR TITLE
Fix: net_http_message_not_success_statuscode_reason, 404, Not Found (#961)

### DIFF
--- a/BBDown.Core/Parser.cs
+++ b/BBDown.Core/Parser.cs
@@ -30,7 +30,7 @@ public static partial class Parser
         if (appApi) return await AppHelper.DoReqAsync(aid, cid, epId, qn, bangumi, encoding, Config.TOKEN);
 
         string prefix = tvApi ? bangumi ? $"{Config.TVHOST}/pgc/player/api/playurltv" : $"{Config.TVHOST}/x/tv/playurl"
-            : bangumi ? $"{Config.HOST}/pgc/player/web/v2/playurl" : "api.bilibili.com/x/player/wbi/playurl";
+            : bangumi ? $"{Config.HOST}/pgc/player/web/playurl" : "api.bilibili.com/x/player/wbi/playurl";
         prefix = $"https://{prefix}?";
 
         string api;


### PR DESCRIPTION
## 描述

我在使用 BBDown 下载课堂视频时出现 `net_http_message_not_success_statuscode_reason, 404, Not Found` 错误。

下图是使用 `--debug` 获取到的信息：

<img width="1898" height="231" alt="BBDown" src="https://github.com/user-attachments/assets/75c18fc2-83e9-4701-9f99-20c617b8533f" />
<img width="1884" height="475" alt="BBDown_1" src="https://github.com/user-attachments/assets/b26b40b6-94b7-4aed-8941-a00b5f21762f" />

定位发现是 API 路径有误，应将 `pgc/player/web/v2/playurl` 更改为 `pgc/player/web/playurl`。
修改后测试正常，可以下载课堂视频。

<img width="1891" height="893" alt="图片" src="https://github.com/user-attachments/assets/61bac6a9-ea47-46ef-af6d-250b85388b26" />

<img width="1898" height="819" alt="图片" src="https://github.com/user-attachments/assets/8a2dad55-1ee8-42f2-b885-e3f445614591" />

## 改动

- 修改了错误的 API 路径
- 将 `pgc/player/web/v2/playurl` 更改为 `pgc/player/web/playurl`
- 验证后确认 API 调用已恢复正常