### PR TITLE
修复超过24小时的时长格式化时不正确的问题

### DIFF
--- a/BBDown/BBDownUtil.cs
+++ b/BBDown/BBDownUtil.cs
@@ -195,10 +195,17 @@ static partial class BBDownUtil
 
     public static string FormatTime(int time, bool absolute = false)
     {
-        TimeSpan ts = TimeSpan.FromSeconds(time);
-        return !absolute
-            ? (ts.Hours == 0 ? ts.ToString(@"mm\mss\s") : ts.ToString(@"hh\hmm\mss\s"))
-            : ts.ToString(@"hh\:mm\:ss");
+        var ts = TimeSpan.FromSeconds(time);
+        var totalHours = (int)ts.TotalHours;
+        var minutes = ts.Minutes;
+        var seconds = ts.Seconds;
+
+        if (absolute)
+        {
+            return $"{totalHours:D2}:{minutes:D2}:{seconds:D2}";
+        }
+
+        return totalHours == 0 ? $"{minutes:D2}m{seconds:D2}s" : $"{totalHours}h{minutes:D2}m{seconds:D2}s";
     }
 
     /// <summary>


### PR DESCRIPTION
Fix #1051

<img width="1216" height="244" alt="PixPin_2025-09-07_08-47-25" src="https://github.com/user-attachments/assets/6e800dc6-ffbe-41a3-8182-4a00d4350821" />
